### PR TITLE
ETH-1INCH strategy

### DIFF
--- a/contracts/strategies/1inch/OneInchStrategyMainnet_ETH_ONEINCH.sol
+++ b/contracts/strategies/1inch/OneInchStrategyMainnet_ETH_ONEINCH.sol
@@ -1,0 +1,25 @@
+pragma solidity 0.5.16;
+
+import "./OneInchStrategy_ETH_X.sol";
+
+
+/**
+* This strategy is for the ETH/DAI LP token on 1inch
+*/
+contract OneInchStrategy_ETH_ONEINCH is OneInchStrategy_ETH_X {
+
+  address public oneInch = address(0x111111111117dC0aa78b770fA6A738034120C302);
+
+  constructor(
+    address _storage,
+    address _vault
+  ) OneInchStrategy_ETH_X (
+    _storage,
+    _vault,
+    address(0x0EF1B8a0E726Fc3948E15b23993015eB1627f210), // underlying
+    address(0xeb7DBc5a64d2D083d774595E560b147C5021Eacd), // pool
+    address(0x0EF1B8a0E726Fc3948E15b23993015eB1627f210)  // oneInchEthLP
+  ) public {
+    require(token1 == oneInch, "token1 mismatch");
+  }
+}

--- a/test/1inch/eth-oneInch.js
+++ b/test/1inch/eth-oneInch.js
@@ -1,0 +1,104 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const OneInchStrategy_ETH_ONEINCH = artifacts.require("OneInchStrategy_ETH_ONEINCH");
+
+// Developed this test forking on blockNumber 11901500
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet ETH/1INCH", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  // use block 11807770
+  let underlyingWhale = "0x5e73cB1ba8a0bdC566696b95bc17415EB4b2a1b5";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x0EF1B8a0E726Fc3948E15b23993015eB1627f210");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    console.log(BigNumber(farmerBalance).toFixed());
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": OneInchStrategy_ETH_ONEINCH,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      console.log(farmerOldBalance.toFixed())
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(farmerBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      console.log("earned!");
+
+    });
+  });
+});


### PR DESCRIPTION
I have seen several requests for the 1INCH-ETH pool that is part of the 1INCH farming program, so I created a strategy to farm it.

The test can be run using `npx hardhat test ./test/1inch/eth-oneInch.js`. I developed and ran it on blockNumber 11901500. Output is shown below:
```
  Mainnet ETH/1INCH
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x5e73cB1ba8a0bdC566696b95bc17415EB4b2a1b5
Fetching Underlying at:  0x0EF1B8a0E726Fc3948E15b23993015eB1627f210
New Vault Deployed:  0x57c0b610FeDcc510c9E1680fbe5Ba096917D69D5
Strategy Deployed:  0xF2004f64F71F110e9e50B5Ff36253fE8785b2BCc
Strategy and vault added to Controller.
12997859236229418399993
    Happy path
12997859236229418399993
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000799012494988244
growth:  1.0007990124949884
loop  2
old shareprice:  1000799012494988244
new shareprice:  1001599900479902282
growth:  1.0008002485763026
loop  3
old shareprice:  1001599900479902282
new shareprice:  1002401378469782345
growth:  1.000800197753111
loop  4
old shareprice:  1002401378469782345
new shareprice:  1003203475570011084
growth:  1.000800175575829
loop  5
old shareprice:  1003203475570011084
new shareprice:  1004006197775419621
growth:  1.0008001589158695
loop  6
old shareprice:  1004006197775419621
new shareprice:  1004809548617394378
growth:  1.0008001453016473
loop  7
old shareprice:  1004809548617394378
new shareprice:  1005613530274030687
growth:  1.0008001333762628
loop  8
old shareprice:  1005613530274030687
new shareprice:  1006418165093230637
growth:  1.0008001431911726
loop  9
old shareprice:  1006418165093230637
new shareprice:  1007223412286427070
growth:  1.0008001119426553
earned!
      √ Farmer should earn money
1 passing (55s)
```

The pool is part of 1Inch farming program ([](https://1inch.exchange/#/dao/farming)). The pool can be found here [](https://etherscan.io/address/0xeb7dbc5a64d2d083d774595e560b147c5021eacd).

Rewards are supposed to run for another 2 weeks, till the 6th of March end of day.

I think this is a good opportunity, as there have been multiple requests in the discord and the return is proper. With 0.16% per day at the moment of testing, this equals about 80% APY.