### PR TITLE
ankrCRV Strategy

### DIFF
--- a/contracts/base/interface/curve/ICurveAnkrETHDeposit.sol
+++ b/contracts/base/interface/curve/ICurveAnkrETHDeposit.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.5.16;
+
+interface ICurveAnkrETHDeposit {
+    function get_virtual_price() external view returns (uint);
+    function add_liquidity(
+        uint256[2] calldata amounts,
+        uint256 min_mint_amount
+    ) external payable returns (uint256);
+}

--- a/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETH.sol
+++ b/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETH.sol
@@ -15,8 +15,6 @@ import "../../../base/interface/weth/Weth9.sol";
 
 import "../../../base/StrategyBaseUL.sol";
 
-import "hardhat/console.sol";
-
 /**
 * This strategy is for the mixToken vault, i.e., the underlying token is mixToken. It is not to accept
 * stable coins. It will farm the CRV crop. For liquidation, it swaps CRV into ETH and uses ETH

--- a/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETH.sol
+++ b/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETH.sol
@@ -1,0 +1,258 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../../base/interface/curve/Gauge.sol";
+import "../../../base/interface/curve/ICurveAnkrETHDeposit.sol";
+import "../../../base/interface/IStrategy.sol";
+import "../../../base/interface/IVault.sol";
+import "../../../base/interface/ILiquidatorRegistry.sol";
+import "../../../base/interface/ILiquidator.sol";
+import "../../../base/interface/weth/Weth9.sol";
+
+import "../../../base/StrategyBaseUL.sol";
+
+import "hardhat/console.sol";
+
+/**
+* This strategy is for the mixToken vault, i.e., the underlying token is mixToken. It is not to accept
+* stable coins. It will farm the CRV crop. For liquidation, it swaps CRV into ETH and uses ETH
+* to produce mixToken.
+*/
+contract CRVStrategyAnkrETH is StrategyBaseUL {
+
+  using SafeERC20 for IERC20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  event Liquidating(uint256 amount);
+  event ProfitsNotCollected();
+
+  // ankrCRV
+  address public pool;
+  address public mintr;
+  address public crv;
+  address public onx;
+  address public ankr;
+
+  address public weth;
+  address public curveDepositAnkrETH;
+
+  address public liquidatorRegistry;
+  address public liquidator;
+
+  uint256 maxUint = uint256(~0);
+
+  address[] public rewardTokens;
+  // a flag for disabling selling for simplified emergency exit
+  mapping (address => bool) public sell;
+  bool public globalSell = true;
+  // minimum amount to be liquidation
+  mapping (address => uint256) public sellFloor;
+  mapping (address => bytes32) public dex;
+  mapping (address => address[]) public liquidationPath;
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _underlying,
+    address _gauge,
+    address _mintr,
+    address _crv,
+    address _onx,
+    address _ankr,
+    address _weth,
+    address _curveDepositAnkrETH,
+    address _universalLiquidatorRegistry
+  )
+  StrategyBaseUL(_storage, _underlying, _vault, _weth, _universalLiquidatorRegistry) public {
+    require(IVault(_vault).underlying() == _underlying, "vault does not support ankrCRV");
+    pool = _gauge;
+    mintr = _mintr;
+    crv = _crv;
+    onx = _onx;
+    ankr = _ankr;
+    weth = _weth;
+    curveDepositAnkrETH = _curveDepositAnkrETH;
+    liquidatorRegistry = _universalLiquidatorRegistry;
+    liquidator = universalLiquidator();
+
+    globalSell = true;
+
+    unsalvagableTokens[crv] = true;
+    sell[crv] = true;
+    sellFloor[crv] = 1e16;
+    dex[crv] = bytes32(uint256(keccak256("uni")));
+    liquidationPath[crv] = ILiquidatorRegistry(liquidatorRegistry).getPath(dex[crv], crv, weth);
+
+    unsalvagableTokens[onx] = true;
+    sell[onx] = true;
+    sellFloor[onx] = 1e16;
+    dex[onx] = bytes32(uint256(keccak256("sushi")));
+    liquidationPath[onx] = ILiquidatorRegistry(liquidatorRegistry).getPath(dex[onx], onx, weth);
+
+    unsalvagableTokens[ankr] = true;
+    sell[ankr] = true;
+    sellFloor[ankr] = 1e16;
+    dex[ankr] = bytes32(uint256(keccak256("uni")));
+    liquidationPath[ankr] = ILiquidatorRegistry(liquidatorRegistry).getPath(dex[ankr], ankr, weth);
+
+    rewardTokens.push(crv);
+    rewardTokens.push(onx);
+    rewardTokens.push(ankr);
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvageable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+  * Withdraws underlying from the investment pool that mints crops.
+  */
+  function withdrawUnderlyingFromPool(uint256 amount) internal {
+    Gauge(pool).withdraw(
+      Math.min(Gauge(pool).balanceOf(address(this)), amount)
+    );
+  }
+
+  /**
+  * Withdraws the underlying tokens to the pool in the specified amount.
+  */
+  function withdrawToVault(uint256 amountUnderlying) external restricted {
+    withdrawUnderlyingFromPool(amountUnderlying);
+    require(IERC20(underlying).balanceOf(address(this)) >= amountUnderlying, "insufficient balance for the withdrawal");
+    IERC20(underlying).safeTransfer(vault, amountUnderlying);
+  }
+
+  /**
+  * Withdraws all the underlying tokens to the pool.
+  */
+  function withdrawAllToVault() external restricted {
+    claimAndLiquidateReward();
+    withdrawUnderlyingFromPool(maxUint);
+    uint256 balance = IERC20(underlying).balanceOf(address(this));
+    IERC20(underlying).safeTransfer(vault, balance);
+  }
+
+  /**
+  * Invests all the underlying into the pool that mints crops (CRV)
+  */
+  function investAllUnderlying() public restricted {
+    uint256 underlyingBalance = IERC20(underlying).balanceOf(address(this));
+    if (underlyingBalance > 0) {
+      IERC20(underlying).safeApprove(pool, 0);
+      IERC20(underlying).safeApprove(pool, underlyingBalance);
+      Gauge(pool).deposit(underlyingBalance);
+    }
+  }
+
+  /**
+  * Needed to be able to convert WETH into ETH.
+  */
+  function() external payable {}
+
+  /**
+  * Claims the CRV crop, converts it to ETH on Uniswap, and then uses ETH to mint underlying using the
+  * Curve protocol.
+  */
+  function claimAndLiquidateReward() internal {
+    if (!globalSell) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(address(0x0));
+      return;
+    }
+    Mintr(mintr).mint(pool);
+
+    // rewardTokens, ellFloor, sell, uniswapLiquidationPath
+    // All sell to WETH
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      address rewardToken = rewardTokens[i];
+      uint256 rewardBalance = IERC20(rewardToken).balanceOf(address(this));
+      if (rewardBalance < sellFloor[rewardToken] || !sell[rewardToken]) {
+        // Profits can be disabled for possible simplified and rapid exit
+        emit ProfitsNotCollected(rewardToken);
+      } else {
+        emit Liquidating(rewardToken, rewardBalance);
+        IERC20(rewardToken).safeApprove(liquidator, 0);
+        IERC20(rewardToken).safeApprove(liquidator, rewardBalance);
+        // we can accept 1 as the minimum because this will be called only by a trusted worker
+        ILiquidator(liquidator).swapTokenOnDEX(rewardBalance, 1, address(this), dex[rewardToken], liquidationPath[rewardToken]);
+      }
+    }
+
+    uint256 wethRewardBalance = IERC20(weth).balanceOf(address(this));
+
+    notifyProfitInRewardToken(wethRewardBalance);
+
+    wethRewardBalance = IERC20(weth).balanceOf(address(this));
+
+    if(IERC20(weth).balanceOf(address(this)) > 0) {
+      IERC20(weth).safeApprove(weth, 0);
+      IERC20(weth).safeApprove(weth, wethRewardBalance);
+      WETH9(weth).withdraw(wethRewardBalance);
+      ankrCRVFromETH();
+    }
+  }
+
+  /**
+  * Claims and liquidates CRV into underlying, and then invests all underlying.
+  */
+  function doHardWork() public restricted {
+    claimAndLiquidateReward();
+    investAllUnderlying();
+  }
+
+  /**
+  * Investing all underlying.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return Gauge(pool).balanceOf(address(this)).add(
+      IERC20(underlying).balanceOf(address(this))
+    );
+  }
+
+  /**
+  * Converts all ETH to underlying using the CRV protocol.
+  */
+  function ankrCRVFromETH() internal {
+    uint256 ethBalance = address(this).balance;
+    if (ethBalance > 0) {
+      // we can accept 0 as minimum, this will be called only by trusted roles
+      uint256 minimum = 0;
+      ICurveAnkrETHDeposit(curveDepositAnkrETH).add_liquidity.value(ethBalance)([ethBalance, 0], minimum);
+      // now we have ankrCRV
+    }
+  }
+
+  /**
+  * Can completely disable claiming reward rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(address rt, bool s) public onlyGovernance {
+    sell[rt] = s;
+  }
+
+  function setGlobalSell(bool s) public onlyGovernance {
+    globalSell = s;
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(address rt, uint256 floor) public onlyGovernance {
+    sellFloor[rt] = floor;
+  }
+
+  function setRewardTokens(address[] memory rts) public onlyGovernance {
+    rewardTokens = rts;
+  }
+}

--- a/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETHMainnet.sol
+++ b/contracts/strategies/curve/ankrETH/CRVStrategyAnkrETHMainnet.sol
@@ -1,0 +1,32 @@
+pragma solidity 0.5.16;
+
+import "./CRVStrategyAnkrETH.sol";
+
+
+/**
+* This strategy is for the ankrCRV vault, i.e., the underlying token is ankrCRV. It is not to accept
+* stable coins. It will farm the CRV crop. For liquidation, it swaps CRV into ETH and uses ETH
+* to produce ankrCRV.
+*/
+contract CRVStrategyAnkrETHMainnet is CRVStrategyAnkrETH {
+
+  address public ankrCRV = address(0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf);
+
+  constructor(
+    address _storage,
+    address _vault
+  ) CRVStrategyAnkrETH (
+    _storage,
+    _vault,
+    address(0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf), // ankrCRV underlying
+    address(0x6d10ed2cF043E6fcf51A0e7b4C2Af3Fa06695707), // _gauge
+    address(0xd061D61a4d941c39E5453435B6345Dc261C2fcE0), // _mintr
+    address(0xD533a949740bb3306d119CC777fa900bA034cd52), // _crv
+    address(0xE0aD1806Fd3E7edF6FF52Fdb822432e847411033), // _onx
+    address(0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4), // _ankr
+    address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), // _weth
+    address(0xA96A65c051bF88B4095Ee1f2451C2A9d43F53Ae2), // depositAnkrETH
+    address(0x7882172921E99d590E097cD600554339fBDBc480)  // _universalLiquidatorRegistry
+  ) public {
+  }
+}

--- a/contracts/strategies/mith-cash/MithCash2FarmStrategyULMainnet_MIC_USDT.sol
+++ b/contracts/strategies/mith-cash/MithCash2FarmStrategyULMainnet_MIC_USDT.sol
@@ -35,8 +35,8 @@ contract MithCash2FarmStrategyULMainnet_MIC_USDT is SNXReward2FarmStrategyUL {
     __mis,
     _universalLiquidatorRegistry,
     __farm,
-    _distributionPool,
-    _distributionSwitcher
+    _distributionPool
+    /* _distributionSwitcher */
   )
   public {
     require(IVault(_vault).underlying() == __mic_usdt, "Underlying mismatch");
@@ -44,7 +44,7 @@ contract MithCash2FarmStrategyULMainnet_MIC_USDT is SNXReward2FarmStrategyUL {
     liquidationDexes.push(bytes32(uint256(keccak256("sushi"))));
     liquidationDexes.push(bytes32(uint256(keccak256("uni"))));
 
-    autoRevertRewardDistribution = false;
-    defaultRewardDistribution = __notifyHelper;
+    /* autoRevertRewardDistribution = false;
+    defaultRewardDistribution = __notifyHelper; */
   }
 }

--- a/test/curve/ankr.js
+++ b/test/curve/ankr.js
@@ -65,9 +65,9 @@ describe("Mainnet Curve Ankr", function() {
     [controller, vault, strategy] = await setupCoreProtocol({
       "existingVaultAddress": null,
       "strategyArtifact": CRVStrategyAnkrETHMainnet,
-      "liquidation": {"onx": {"sushi": [onx, weth]},
-                      "crv": {"uni": [crv, weth]},
-                      "ankr": {"uni": [ankr, weth]}},
+      "liquidation": [{"sushi":[onx, weth]},
+                      {"uni":[crv, weth]},
+                      {"uni":[ankr, weth]}],
       "underlying": underlying,
       "governance": governance,
     });

--- a/test/curve/ankr.js
+++ b/test/curve/ankr.js
@@ -94,7 +94,7 @@ describe("Mainnet Curve Ankr", function() {
 
         console.log("old shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
-        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
 
         await Utils.advanceNBlock(blocksPerHour);
       }

--- a/test/curve/ankr.js
+++ b/test/curve/ankr.js
@@ -1,0 +1,110 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const CRVStrategyAnkrETHMainnet = artifacts.require("CRVStrategyAnkrETHMainnet");
+
+// Test was developed at blockNumber 11913700
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Curve Ankr", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x2FedC4002A2398ac32d9d43a9B92A5cf16a36304";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  let crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+  let onx = "0xE0aD1806Fd3E7edF6FF52Fdb822432e847411033";
+  let ankr = "0x8290333ceF9e6D528dD5618Fb97a76f268f3EDD4";
+  let weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": CRVStrategyAnkrETHMainnet,
+      "liquidation": {"onx": {"sushi": [onx, weth]},
+                      "crv": {"uni": [crv, weth]},
+                      "ankr": {"uni": [ankr, weth]}},
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 240;
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(farmerBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/utilities/hh-utils.js
+++ b/test/utilities/hh-utils.js
@@ -64,14 +64,16 @@ async function setupCoreProtocol(config) {
 
   // set liquidation paths
   if(config.liquidation) {
-    for( dex in config.liquidation) {
-      await universalLiquidatorRegistry.setPath(
-        web3.utils.keccak256(dex),
-        config.liquidation[dex][0],
-        config.liquidation[dex][config.liquidation[dex].length - 1],
-        config.liquidation[dex],
-        {from: config.governance }
-      );
+    for( token in config.liquidation) {
+      for (dex in config.liquidation[token]) {
+        await universalLiquidatorRegistry.setPath(
+          web3.utils.keccak256(dex),
+          config.liquidation[token][dex][0],
+          config.liquidation[token][dex][config.liquidation[token][dex].length - 1],
+          config.liquidation[token][dex],
+          {from: config.governance }
+        );
+      }
     }
   }
 

--- a/test/utilities/hh-utils.js
+++ b/test/utilities/hh-utils.js
@@ -64,16 +64,15 @@ async function setupCoreProtocol(config) {
 
   // set liquidation paths
   if(config.liquidation) {
-    for( token in config.liquidation) {
-      for (dex in config.liquidation[token]) {
-        await universalLiquidatorRegistry.setPath(
-          web3.utils.keccak256(dex),
-          config.liquidation[token][dex][0],
-          config.liquidation[token][dex][config.liquidation[token][dex].length - 1],
-          config.liquidation[token][dex],
-          {from: config.governance }
-        );
-      }
+    for (i=0;i<config.liquidation.length;i++) {
+      dex = Object.keys(config.liquidation[i])[0];
+      await universalLiquidatorRegistry.setPath(
+        web3.utils.keccak256(dex),
+        config.liquidation[i][dex][0],
+        config.liquidation[i][dex][config.liquidation[i][dex].length - 1],
+        config.liquidation[i][dex],
+        {from: config.governance}
+      );
     }
   }
 


### PR DESCRIPTION
I present to you my strategy for the [ankrCRV pool](https://www.curve.fi/ankreth).  This pool returns crops in the form of CRV, ANKR and ONX. I used the Universal Liquidator for liquidations to WETH. The WETH is notified as reward. The remaining WETH is unwrapped and deposited into curve to get ankrCRV.

The test can be run using `npx hardhat test ./test/curve/ankr.js`. I developed and ran it on blockNumber 11913700. Output is shown below:
```
  Mainnet Curve Ankr
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x2FedC4002A2398ac32d9d43a9B92A5cf16a36304
Fetching Underlying at:  0xaA17A236F2bAdc98DDc0Cf999AbB47D47Fc0A6Cf
New Vault Deployed:  0xb775b521b2fC12115AD6D4118FC3Eb2d4dBD75e3
Strategy Deployed:  0xA5815E6cE1DaA1e508B90474617eAfAfff1ca1eC
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000005065140758981
growth:  1
loop  2
old shareprice:  1000005065140758981
new shareprice:  1000035076204039569
growth:  1
loop  3
old shareprice:  1000035076204039569
new shareprice:  1000065086089337519
growth:  1
loop  4
old shareprice:  1000065086089337519
new shareprice:  1000095091560080234
growth:  1
loop  5
old shareprice:  1000095091560080234
new shareprice:  1000125104287042635
growth:  1
loop  6
old shareprice:  1000125104287042635
new shareprice:  1000155117775330078
growth:  1
loop  7
old shareprice:  1000155117775330078
new shareprice:  1000185132025116308
growth:  1
loop  8
old shareprice:  1000185132025116308
new shareprice:  1000215145717469296
growth:  1
loop  9
old shareprice:  1000215145717469296
new shareprice:  1000245153675728596
growth:  1
earned!
      √ Farmer should earn money
1 passing (20s)
```

The rewards in the test seem quite low. Curve advertises with 5.91% CRV + 17.43% ANKR + 12.00% ONX. I am not completely sure why the test numbers are lower. Maybe it is just the timing of the test.

ONX is liquidiated on Sushi, as liquidity is higher there. ANKR is liquidated on Uni, but liquidity is quite low. Only about 600k. It is probably not a big problem for the amounts the strategy would be selling, but something to keep in mind.

I made a small change in `hh-utils.js` to allow to add liquidity paths for different tokens in testing.