### PR TITLE
mNFLX-UST strategy

### DIFF
--- a/contracts/strategies/mirror-finance/MirrorMainnet_mNFLX_UST.sol
+++ b/contracts/strategies/mirror-finance/MirrorMainnet_mNFLX_UST.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.5.16;
+
+import "../../base/snx-base/interfaces/SNXRewardInterface.sol";
+import "../../base/snx-base/SNXReward2FarmStrategyUL.sol";
+
+contract MirrorMainnet_mNFLX_UST is SNXReward2FarmStrategyUL {
+
+  address public ust = address(0xa47c8bf37f92aBed4A126BDA807A7b7498661acD);
+  address public mnflx_ust = address(0xC99A74145682C4b4A6e9fa55d559eb49A6884F75);
+  address public mnflx = address(0xC8d674114bac90148d11D3C1d33C61835a0F9DCD);
+  address public mir = address(0x09a3EcAFa817268f77BE1283176B946C4ff2E608);
+  address public weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+  address public mNFLXUSTRewardPool = address(0x29cF719d134c1C18daB61C2F4c0529C4895eCF44);
+  address public constant universalLiquidatorRegistry = address(0x7882172921E99d590E097cD600554339fBDBc480);
+  address public constant farm = address(0xa0246c9032bC3A600820415aE600c6388619A14D);
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _distributionPool
+  )
+  SNXReward2FarmStrategyUL(_storage, mnflx_ust, _vault, mNFLXUSTRewardPool, mir, universalLiquidatorRegistry, farm, _distributionPool)
+  public {
+    require(IVault(_vault).underlying() == mnflx_ust, "Underlying mismatch");
+    liquidationPath = [mir, farm];
+    liquidationDexes.push(bytes32(uint256(keccak256("uni"))));
+  }
+}

--- a/test/mirror-finance/mnflx-to-farm.js
+++ b/test/mirror-finance/mnflx-to-farm.js
@@ -1,0 +1,128 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("MirrorMainnet_mNFLX_UST");
+const NoMintRewardPool = artifacts.require("NoMintRewardPool");
+const RewardDistributionSwitcher = artifacts.require("RewardDistributionSwitcher");
+
+//This test was developed at blockNumber 11938650
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("MIR to FARM: mNFLX", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x447f95026107aaed7472A0470931e689f51e0e42";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+  let rewardPool;
+  let farm = "0xa0246c9032bC3A600820415aE600c6388619A14D";
+
+  let mir = "0x09a3EcAFa817268f77BE1283176B946C4ff2E608";
+  let weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xC99A74145682C4b4A6e9fa55d559eb49A6884F75");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy, rewardPool] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArgs": [addresses.Storage, "vaultAddr", "poolAddr"],
+      "rewardPotPool": {"rewardTokens": ["0x1571eD0bed4D987fe2b498DdBaE7DFA19519F651"]},
+      "liquidation": [{"uni": [mir, weth, farm]}],
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    //deploying rewardPool
+    await rewardPool.setRewardDistribution(["0x3D135252D366111cf0621eB0e846243CBb962061"], true, {from: governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+
+    iFarm = await IERC20.at("0x1571eD0bed4D987fe2b498DdBaE7DFA19519F651");
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      let farmerVaultShare = new BigNumber(await vault.balanceOf(farmer1)).toFixed();
+      let vaultERC20 = await IERC20.at(vault.address);
+      await vaultERC20.approve(rewardPool.address, farmerVaultShare, {from: farmer1});
+      await rewardPool.stake(farmerVaultShare, {from: farmer1});
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+        console.log("iFarm in reward pool: ", (new BigNumber(await iFarm.balanceOf(rewardPool.address))).toFixed());
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await rewardPool.exit({from: farmer1});
+      let farmerNewFarm = new BigNumber(await iFarm.balanceOf(farmer1));
+      await vault.withdraw(new BigNumber(await vault.balanceOf(farmer1)).toFixed(), { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+
+      console.log("farmerNewFarm:    ", farmerNewFarm.toFixed());
+      console.log("farmerOldBalance: ", farmerOldBalance.toFixed());
+      console.log("farmerNewBalance: ", farmerNewBalance.toFixed());
+      Utils.assertBNGt(farmerNewFarm, 0);
+      console.log("earned!");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/mirror-finance/mnflx-to-ifarm.js
+++ b/test/mirror-finance/mnflx-to-ifarm.js
@@ -9,8 +9,6 @@ const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol
 
 //const Strategy = artifacts.require("");
 const Strategy = artifacts.require("MirrorMainnet_mNFLX_UST");
-const NoMintRewardPool = artifacts.require("NoMintRewardPool");
-const RewardDistributionSwitcher = artifacts.require("RewardDistributionSwitcher");
 
 //This test was developed at blockNumber 11938650
 

--- a/test/utilities/hh-utils.js
+++ b/test/utilities/hh-utils.js
@@ -59,6 +59,28 @@ async function setupCoreProtocol(config) {
     console.log("Fetching Reward Pool deployed: ", rewardPool.address);
   }
 
+  // if reward pool is required, then deploy it
+  if(config.rewardPotPool != null && config.existingRewardPotPoolAddress == null) {
+    const PotPool = artifacts.require("PotPool");
+    console.log("reward pool needs to be deployed");
+    rewardPool = await PotPool.new(
+      config.rewardPotPool.rewardTokens,
+      vault.address,
+      64800,
+      [config.governance],
+      addresses.Storage,
+      "pfToken",
+      "pfToken",
+      18,
+      {from: config.governance }
+    );
+    console.log("New Reward Pool deployed: ", rewardPool.address);
+  } else if(config.existingRewardPotPoolAddress != null) {
+    const PotPool = artifacts.require("PotPool");
+    rewardPool = await PotPool.at(config.existingRewardPotPoolAddress);
+    console.log("Fetching Reward Pool deployed: ", rewardPool.address);
+  }
+
 
   let universalLiquidatorRegistry = await ILiquidatorRegistry.at(addresses.UniversalLiquidatorRegistry);
 


### PR DESCRIPTION
Strategy to farm mNFLX-UST LP. Rewards are converted and distributed as iFARM.

The test can be run using `npx hardhat test ./test/mirror-finance/mnflx-to-ifarm.js`. I developed and ran it on blockNumber 11938650. Output is shown below:

```
  MIR to FARM: mNFLX
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x447f95026107aaed7472A0470931e689f51e0e42
Fetching Underlying at:  0xC99A74145682C4b4A6e9fa55d559eb49A6884F75
New Vault Deployed:  0xb259717880c57EeaF86Fb7d1FbD3b5066b6DBdB7
reward pool needs to be deployed
New Reward Pool deployed:  0x492191b747B939fFeB7B8598D6dbEeB27026B7C3
Strategy Deployed:  0xef5C8d34e4Eb85f96e6e977F1A91d965547930AB
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  0
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  3300046635432209
loop  2
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  6600085926226236
loop  3
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  9900203810643049
loop  4
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  13200400288133366
loop  5
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  16500417544586223
loop  6
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  19800513394161644
loop  7
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  23100515961367634
loop  8
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  26400511184082613
loop  9
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
iFarm in reward pool:  29700584999419950
farmerNewFarm:     27432627183175351
farmerOldBalance:  13569363722394523410
farmerNewBalance:  13569363722394523410
earned!
      √ Farmer should earn money
1 passing (59s)
```

To setup and use the new PotPool I added a block to the `hh-utils.js` file. I am not sure if the PotPool is the new standard, or if it is only used for "degen" strategies. If it is the new standard, I could replace the rewardPool block to make it more clear.