### PR TITLE
Claimable strategies and general updates

### DIFF
--- a/contracts/base/sushi-base/MasterChefHodlStrategy.sol
+++ b/contracts/base/sushi-base/MasterChefHodlStrategy.sol
@@ -202,7 +202,7 @@ contract MasterChefHodlStrategy is IStrategy, BaseUpgradeableStrategy {
   *   when the investing is being paused by governance.
   */
   function doHardWork() external onlyNotPausedInvesting restricted {
-    exitRewardPool();
+    IMasterChef(rewardPool()).withdraw(poolId(), 0);
     _hodlAndNotify();
     investAllUnderlying();
   }

--- a/contracts/base/sushi-base/MasterChefStrategyWithBuyback.sol
+++ b/contracts/base/sushi-base/MasterChefStrategyWithBuyback.sol
@@ -329,14 +329,13 @@ contract MasterChefStrategyWithBuyback is IStrategy, BaseUpgradeableStrategyClai
   *   when the investing is being paused by governance.
   */
   function doHardWork() external onlyNotPausedInvesting restricted {
-    exitRewardPool();
+    IMasterChef(rewardPool()).withdraw(poolId(), 0);
     _liquidateReward();
     investAllUnderlying();
   }
 
   function _getReward() internal {
-    exitRewardPool();
-    investAllUnderlying();
+    IMasterChef(rewardPool()).withdraw(poolId(), 0);
   }
 
   /**

--- a/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixed.sol
+++ b/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixed.sol
@@ -1,0 +1,226 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../../base/interface/curve/Gauge.sol";
+import "../../../base/interface/curve/ICurveSTETHDeposit.sol";
+import "../../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../../base/interface/IStrategy.sol";
+import "../../../base/interface/IVault.sol";
+import "../../../base/interface/weth/Weth9.sol";
+import "../../../base/StrategyBase.sol";
+import "../../../base/inheritance/RewardTokenProfitNotifier.sol";
+import "./ICurveTBTC.sol";
+
+
+contract CRVStrategyTBTCMixed is IStrategy, RewardTokenProfitNotifier {
+
+  using SafeERC20 for IERC20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  event Liquidating(address rewardToken, uint256 amount);
+  event ProfitsNotCollected(address rewardToken);
+
+  // the mixed token
+  address public underlying;
+  address public pool;
+  address public mintr;
+  address public crv;
+
+  address public curve;
+  address public weth;
+  address public wbtc;
+
+  address public uni;
+
+  // these tokens cannot be claimed by the governance
+  mapping(address => bool) public unsalvagableTokens;
+
+  address public vault;
+
+  uint256 maxUint = uint256(~0);
+  address[] public uniswap_CRV2WBTC;
+
+  // a flag for disabling selling for simplified emergency exit
+  bool public sell = true;
+
+  // minimum CRV amount to be liquidated
+  uint256 public sellFloor = 1e18;
+
+  modifier restricted() {
+    require(msg.sender == vault || msg.sender == controller()
+      || msg.sender == governance(),
+      "The sender has to be the controller, governance, or vault");
+    _;
+  }
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _underlying,
+    address _gauge,
+    address _mintr,
+    address _crv,
+    address _curve,
+    address _weth,
+    address _wbtc,
+    address _uniswap
+  )
+  RewardTokenProfitNotifier(_storage, _crv) public {
+    require(IVault(_vault).underlying() == _underlying, "vault does not support TBTC-mixed");
+    vault = _vault;
+    underlying = _underlying;
+    pool = _gauge;
+    mintr = _mintr;
+    crv = _crv;
+    curve = _curve;
+    weth = _weth;
+    wbtc = _wbtc;
+    uni = _uniswap;
+    uniswap_CRV2WBTC = [crv, weth, wbtc];
+    // set these tokens to be not salvageable
+    unsalvagableTokens[underlying] = true;
+    unsalvagableTokens[crv] = true;
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  /**
+  * Salvages a token. We should not be able to salvage CRV and the mixed token (underlying).
+  */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvageable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+  * Withdraws the mixed token from the investment pool that mints crops.
+  */
+  function withdrawMixedFromPool(uint256 amount) internal {
+    Gauge(pool).withdraw(
+      Math.min(Gauge(pool).balanceOf(address(this)), amount)
+    );
+  }
+
+  /**
+  * Withdraws the the mixed token tokens to the pool in the specified amount.
+  */
+  function withdrawToVault(uint256 amountUnderlying) external restricted {
+    withdrawMixedFromPool(amountUnderlying);
+    if (IERC20(underlying).balanceOf(address(this)) < amountUnderlying) {
+      claimAndLiquidateCrv();
+    }
+    uint256 toTransfer = Math.min(IERC20(underlying).balanceOf(address(this)), amountUnderlying);
+    IERC20(underlying).safeTransfer(vault, toTransfer);
+  }
+
+  /**
+  * Withdraws all the the mixed token tokens to the pool.
+  */
+  function withdrawAllToVault() external restricted {
+    claimAndLiquidateCrv();
+    withdrawMixedFromPool(maxUint);
+    uint256 balance = IERC20(underlying).balanceOf(address(this));
+    IERC20(underlying).safeTransfer(vault, balance);
+  }
+
+  /**
+  * Invests all the underlying the mixed token into the pool that mints crops.
+  */
+  function investAllUnderlying() public restricted {
+    uint256 underlyingBalance = IERC20(underlying).balanceOf(address(this));
+    if (underlyingBalance > 0) {
+      IERC20(underlying).safeApprove(pool, 0);
+      IERC20(underlying).safeApprove(pool, underlyingBalance);
+      Gauge(pool).deposit(underlyingBalance);
+    }
+  }
+
+  /**
+  * Claims the CRV, converts them into WBTC on Uniswap, and then uses WBTC to mint the mixed token using the
+  * Curve protocol.
+  */
+  function claimAndLiquidateCrv() internal {
+    if (!sell) {
+      emit ProfitsNotCollected(crv);
+    } else {
+      Mintr(mintr).mint(pool);
+      uint256 crvBalance = IERC20(crv).balanceOf(address(this));
+      if (crvBalance < sellFloor) {
+        emit ProfitsNotCollected(crv);
+      } else {
+        notifyProfitInRewardToken(crvBalance);
+        crvBalance = IERC20(crv).balanceOf(address(this));
+        emit Liquidating(crv, crvBalance);
+
+        IERC20(crv).safeApprove(uni, 0);
+        IERC20(crv).safeApprove(uni, crvBalance);
+        // we can accept 1 as the minimum because this will be called only by a trusted worker
+        IUniswapV2Router02(uni).swapExactTokensForTokens(
+          crvBalance, 1, uniswap_CRV2WBTC, address(this), block.timestamp
+        );
+      }
+    }
+
+    uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(address(this));
+    if (wbtcBalanceAfter > 0) {
+      curveMixedFromWBTC();
+    }
+  }
+
+  /**
+  * Claims and liquidates CRV into the mixed token, and then invests all underlying.
+  */
+  function doHardWork() public restricted {
+    claimAndLiquidateCrv();
+    investAllUnderlying();
+  }
+
+  /**
+  * Investing all underlying.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return Gauge(pool).balanceOf(address(this)).add(
+      IERC20(underlying).balanceOf(address(this))
+    );
+  }
+
+  /**
+  * Uses the Curve protocol to convert the underlying asset into the mixed token.
+  */
+  function curveMixedFromWBTC() internal {
+    uint256 wbtcBalance = IERC20(wbtc).balanceOf(address(this));
+    if (wbtcBalance > 0) {
+      IERC20(wbtc).safeApprove(curve, 0);
+      IERC20(wbtc).safeApprove(curve, wbtcBalance);
+      uint256 minimum = 0;
+      ICurveTBTC(curve).add_liquidity([0, 0, wbtcBalance, 0], minimum);
+    }
+  }
+
+  /**
+  * Can completely disable claiming CRV rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    sell = s;
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    sellFloor = floor;
+  }
+
+  function setLiquidationPath(address[] memory _crvPath) public onlyGovernance {
+    uniswap_CRV2WBTC = _crvPath;
+  }
+}

--- a/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedClaimable.sol
+++ b/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedClaimable.sol
@@ -1,0 +1,254 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../../base/interface/curve/Gauge.sol";
+import "../../../base/interface/curve/ICurveSTETHDeposit.sol";
+import "../../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../../base/interface/IStrategy.sol";
+import "../../../base/interface/IVault.sol";
+import "../../../base/interface/weth/Weth9.sol";
+import "../../../base/StrategyBase.sol";
+import "../../../base/inheritance/RewardTokenProfitNotifier.sol";
+import "./ICurveTBTC.sol";
+
+
+contract CRVStrategyTBTCMixedClaimable is IStrategy, RewardTokenProfitNotifier {
+
+  using SafeERC20 for IERC20;
+  using Address for address;
+  using SafeMath for uint256;
+
+  event Liquidating(address rewardToken, uint256 amount);
+  event ProfitsNotCollected(address rewardToken);
+
+  // the mixed token
+  address public underlying;
+  address public pool;
+  address public mintr;
+  address public crv;
+
+  address public curve;
+  address public weth;
+  address public wbtc;
+
+  address public uni;
+
+  // these tokens cannot be claimed by the governance
+  mapping(address => bool) public unsalvagableTokens;
+
+  address public vault;
+
+  uint256 maxUint = uint256(~0);
+  address[] public uniswap_CRV2WBTC;
+
+  // a flag for disabling selling for simplified emergency exit
+  bool public sell = true;
+
+  // minimum CRV amount to be liquidated
+  uint256 public sellFloor = 1e18;
+
+  bool public allowedRewardClaimable = false;
+  address public multiSig = 0xF49440C1F012d041802b25A73e5B0B9166a75c02;
+
+  modifier restricted() {
+    require(msg.sender == vault || msg.sender == controller()
+      || msg.sender == governance(),
+      "The sender has to be the controller, governance, or vault");
+    _;
+  }
+
+  modifier onlyMultiSigOrGovernance() {
+    require(msg.sender == multiSig || msg.sender == governance(), "The sender has to be multiSig or governance");
+    _;
+  }
+
+  constructor(
+    address _storage,
+    address _vault,
+    address _underlying,
+    address _gauge,
+    address _mintr,
+    address _crv,
+    address _curve,
+    address _weth,
+    address _wbtc,
+    address _uniswap
+  )
+  RewardTokenProfitNotifier(_storage, _crv) public {
+    require(IVault(_vault).underlying() == _underlying, "vault does not support TBTC-mixed");
+    vault = _vault;
+    underlying = _underlying;
+    pool = _gauge;
+    mintr = _mintr;
+    crv = _crv;
+    curve = _curve;
+    weth = _weth;
+    wbtc = _wbtc;
+    uni = _uniswap;
+    uniswap_CRV2WBTC = [crv, weth, wbtc];
+    // set these tokens to be not salvageable
+    unsalvagableTokens[underlying] = true;
+    unsalvagableTokens[crv] = true;
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  /**
+  * Salvages a token. We should not be able to salvage CRV and the mixed token (underlying).
+  */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvageable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /**
+  * Withdraws the mixed token from the investment pool that mints crops.
+  */
+  function withdrawMixedFromPool(uint256 amount) internal {
+    Gauge(pool).withdraw(
+      Math.min(Gauge(pool).balanceOf(address(this)), amount)
+    );
+  }
+
+  /**
+  * Withdraws the the mixed token tokens to the pool in the specified amount.
+  */
+  function withdrawToVault(uint256 amountUnderlying) external restricted {
+    withdrawMixedFromPool(amountUnderlying);
+    if (IERC20(underlying).balanceOf(address(this)) < amountUnderlying) {
+      claimAndLiquidateCrv();
+    }
+    uint256 toTransfer = Math.min(IERC20(underlying).balanceOf(address(this)), amountUnderlying);
+    IERC20(underlying).safeTransfer(vault, toTransfer);
+  }
+
+  /**
+  * Withdraws all the the mixed token tokens to the pool.
+  */
+  function withdrawAllToVault() external restricted {
+    claimAndLiquidateCrv();
+    withdrawMixedFromPool(maxUint);
+    uint256 balance = IERC20(underlying).balanceOf(address(this));
+    IERC20(underlying).safeTransfer(vault, balance);
+  }
+
+  /**
+  * Invests all the underlying the mixed token into the pool that mints crops.
+  */
+  function investAllUnderlying() public restricted {
+    uint256 underlyingBalance = IERC20(underlying).balanceOf(address(this));
+    if (underlyingBalance > 0) {
+      IERC20(underlying).safeApprove(pool, 0);
+      IERC20(underlying).safeApprove(pool, underlyingBalance);
+      Gauge(pool).deposit(underlyingBalance);
+    }
+  }
+
+  /**
+  * Claims the CRV, converts them into WBTC on Uniswap, and then uses WBTC to mint the mixed token using the
+  * Curve protocol.
+  */
+  function claimAndLiquidateCrv() internal {
+    if (!sell) {
+      emit ProfitsNotCollected(crv);
+    } else {
+      Mintr(mintr).mint(pool);
+      uint256 crvBalance = IERC20(crv).balanceOf(address(this));
+      if (crvBalance < sellFloor) {
+        emit ProfitsNotCollected(crv);
+      } else {
+        notifyProfitInRewardToken(crvBalance);
+        crvBalance = IERC20(crv).balanceOf(address(this));
+        emit Liquidating(crv, crvBalance);
+
+        IERC20(crv).safeApprove(uni, 0);
+        IERC20(crv).safeApprove(uni, crvBalance);
+        // we can accept 1 as the minimum because this will be called only by a trusted worker
+        IUniswapV2Router02(uni).swapExactTokensForTokens(
+          crvBalance, 1, uniswap_CRV2WBTC, address(this), block.timestamp
+        );
+      }
+    }
+
+    uint256 wbtcBalanceAfter = IERC20(wbtc).balanceOf(address(this));
+    if (wbtcBalanceAfter > 0) {
+      curveMixedFromWBTC();
+    }
+  }
+
+  /**
+  * Claims and liquidates CRV into the mixed token, and then invests all underlying.
+  */
+  function doHardWork() public restricted {
+    claimAndLiquidateCrv();
+    investAllUnderlying();
+  }
+
+  /**
+  * Investing all underlying.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    return Gauge(pool).balanceOf(address(this)).add(
+      IERC20(underlying).balanceOf(address(this))
+    );
+  }
+
+  /**
+  * Uses the Curve protocol to convert the underlying asset into the mixed token.
+  */
+  function curveMixedFromWBTC() internal {
+    uint256 wbtcBalance = IERC20(wbtc).balanceOf(address(this));
+    if (wbtcBalance > 0) {
+      IERC20(wbtc).safeApprove(curve, 0);
+      IERC20(wbtc).safeApprove(curve, wbtcBalance);
+      uint256 minimum = 0;
+      ICurveTBTC(curve).add_liquidity([0, 0, wbtcBalance, 0], minimum);
+    }
+  }
+
+  function setMultiSig(address _address) public onlyGovernance {
+    multiSig = _address;
+  }
+
+  // reward claiming by multiSig for some strategies
+  function claimReward() public onlyMultiSigOrGovernance {
+    require(allowedRewardClaimable, "reward claimable is not allowed");
+    _getRewards();
+    uint256 rewardBalance = IERC20(rewardToken).balanceOf(address(this));
+    IERC20(rewardToken).safeTransfer(msg.sender, rewardBalance);
+  }
+
+  function _getRewards() internal {
+    Mintr(mintr).mint(pool);
+  }
+
+  function setRewardClaimable(bool flag) public onlyGovernance {
+    allowedRewardClaimable = flag;
+  }
+
+  /**
+  * Can completely disable claiming CRV rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    sell = s;
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    sellFloor = floor;
+  }
+
+  function setLiquidationPath(address[] memory _crvPath) public onlyGovernance {
+    uniswap_CRV2WBTC = _crvPath;
+  }
+}

--- a/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedMainnet.sol
+++ b/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedMainnet.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.16;
 
-import "./CRVStrategyTBTCMixed.sol";
+import "./CRVStrategyTBTCMixedClaimable.sol";
 
 
 /**
@@ -8,12 +8,12 @@ import "./CRVStrategyTBTCMixed.sol";
 * stable coins. It will farm the CRV and KEEP crop. For liquidation, it swaps CRV and KEEP into WBTC and uses WBTC
 * to produce the TBTC-mixed token.
 */
-contract CRVStrategyTBTCMixedMainnet is CRVStrategyTBTCMixed {
+contract CRVStrategyTBTCMixedMainnet is CRVStrategyTBTCMixedClaimable {
 
   constructor(
     address _storage,
     address _vault
-  ) CRVStrategyTBTCMixed(
+  ) CRVStrategyTBTCMixedClaimable(
     _storage,
     _vault,
     address(0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd), // underlying

--- a/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedMainnet.sol
+++ b/contracts/strategies/curve/tbtc/CRVStrategyTBTCMixedMainnet.sol
@@ -1,0 +1,29 @@
+pragma solidity 0.5.16;
+
+import "./CRVStrategyTBTCMixed.sol";
+
+
+/**
+* This strategy is for the TBTC-mixed vault. It is not to accept
+* stable coins. It will farm the CRV and KEEP crop. For liquidation, it swaps CRV and KEEP into WBTC and uses WBTC
+* to produce the TBTC-mixed token.
+*/
+contract CRVStrategyTBTCMixedMainnet is CRVStrategyTBTCMixed {
+
+  constructor(
+    address _storage,
+    address _vault
+  ) CRVStrategyTBTCMixed(
+    _storage,
+    _vault,
+    address(0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd), // underlying
+    address(0x6828bcF74279eE32f2723eC536c22c51Eed383C6), // _gauge
+    address(0xd061D61a4d941c39E5453435B6345Dc261C2fcE0), // _mintr
+    address(0xD533a949740bb3306d119CC777fa900bA034cd52), // _crv
+    address(0xaa82ca713D94bBA7A89CEAB55314F9EfFEdDc78c), // _curve
+    address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2), // _weth
+    address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599), // _wbtc
+    address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D) // _uniswap
+  ) public {
+  }
+}

--- a/contracts/strategies/curve/tbtc/ICurveTBTC.sol
+++ b/contracts/strategies/curve/tbtc/ICurveTBTC.sol
@@ -1,0 +1,8 @@
+pragma solidity 0.5.16;
+
+interface ICurveTBTC {
+    function add_liquidity(
+        uint256[4] calldata amounts,
+        uint256 min_mint_amount
+    ) external returns (uint256);
+}

--- a/contracts/strategies/curve/tbtc/IKeepRewardsClaimable.sol
+++ b/contracts/strategies/curve/tbtc/IKeepRewardsClaimable.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.5.16;
+
+interface IKeepRewardsClaimable {
+  function claim_rewards() external;
+}

--- a/contracts/strategies/idle/IdleFinanceStrategy.sol
+++ b/contracts/strategies/idle/IdleFinanceStrategy.sol
@@ -212,7 +212,7 @@ contract IdleFinanceStrategy is IStrategy, RewardTokenProfitNotifier {
   function liquidateAave() internal {
     if (!sellAave) {
       // Profits can be disabled for possible simplified and rapid exit
-      emit ProfitsNotCollected(comp);
+      emit ProfitsNotCollected(aave);
       return;
     }
 

--- a/contracts/strategies/idle/IdleFinanceStrategy.sol
+++ b/contracts/strategies/idle/IdleFinanceStrategy.sol
@@ -217,10 +217,25 @@ contract IdleFinanceStrategy is IStrategy, RewardTokenProfitNotifier {
     }
 
     // no profit notification, comp is liquidated to IDLE and will be notified there
+    uint256 claimable = IStakedAave(stkaave).stakerRewardsToClaim(address(this));
+    if (claimable > 0) {
+      IStakedAave(stkaave).claimRewards(address(this), claimable);
+    }
 
     uint256 stkAaveBalance = IERC20(stkaave).balanceOf(address(this));
+    uint256 cooldown = IStakedAave(stkaave).stakersCooldowns(address(this));
     if (stkAaveBalance > 0) {
-      IStakedAave(stkaave).redeem(address(this), stkAaveBalance);
+      if (cooldown == 0) {
+        IStakedAave(stkaave).cooldown();
+      } else if (
+        block.timestamp > cooldown.add(IStakedAave(stkaave).COOLDOWN_SECONDS()) && //earliest time to unstake
+        block.timestamp <= cooldown.add(IStakedAave(stkaave).COOLDOWN_SECONDS().add(IStakedAave(stkaave).UNSTAKE_WINDOW())) //latest time to unstake
+        )
+      {
+        IStakedAave(stkaave).redeem(address(this), stkAaveBalance);
+      } else if (block.timestamp > cooldown.add(IStakedAave(stkaave).COOLDOWN_SECONDS().add(IStakedAave(stkaave).UNSTAKE_WINDOW()))) {
+        IStakedAave(stkaave).cooldown();
+      }
     }
     uint256 aaveBalance = IERC20(aave).balanceOf(address(this));
     if (aaveBalance > 0) {

--- a/contracts/strategies/idle/IdleFinanceStrategyClaimable.sol
+++ b/contracts/strategies/idle/IdleFinanceStrategyClaimable.sol
@@ -1,0 +1,310 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/inheritance/RewardTokenProfitNotifier.sol";
+import "../../base/interface/IStrategy.sol";
+import "../../base/interface/IVault.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "./interface/IdleToken.sol";
+import "./interface/IIdleTokenHelper.sol";
+import "./interface/IStakedAave.sol";
+
+contract IdleFinanceStrategyClaimable is IStrategy, RewardTokenProfitNotifier {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  event ProfitsNotCollected(address);
+  event Liquidating(address, uint256);
+
+  address public referral;
+  IERC20 public underlying;
+  address public idleUnderlying;
+  uint256 public virtualPrice;
+  IIdleTokenHelper public idleTokenHelper;
+
+  address public vault;
+  address public comp;
+  address public stkaave;
+  address public aave;
+  address public idle;
+
+  address[] public uniswapComp;
+  address[] public uniswapAave;
+  address[] public uniswapIdle;
+
+  address public uniswapRouterV2;
+
+  bool public sellComp;
+  bool public sellAave;
+  bool public sellIdle;
+  bool public claimAllowed;
+  bool public protected;
+
+  bool public allowedRewardClaimable = false;
+  address public multiSig = 0xF49440C1F012d041802b25A73e5B0B9166a75c02;
+
+  // These tokens cannot be claimed by the controller
+  mapping (address => bool) public unsalvagableTokens;
+
+  modifier restricted() {
+    require(msg.sender == vault || msg.sender == address(controller()) || msg.sender == address(governance()),
+      "The sender has to be the controller or vault or governance");
+    _;
+  }
+
+  modifier onlyMultiSigOrGovernance() {
+    require(msg.sender == multiSig || msg.sender == governance(), "The sender has to be multiSig or governance");
+    _;
+  }
+
+  modifier updateVirtualPrice() {
+    if (protected) {
+      require(virtualPrice <= idleTokenHelper.getRedeemPrice(idleUnderlying), "virtual price is higher than needed");
+    }
+    _;
+    virtualPrice = idleTokenHelper.getRedeemPrice(idleUnderlying);
+  }
+
+  constructor(
+    address _storage,
+    address _underlying,
+    address _idleUnderlying,
+    address _vault,
+    address _comp,
+    address _stkaave,
+    address _aave,
+    address _idle,
+    address _weth,
+    address _uniswap
+  ) RewardTokenProfitNotifier(_storage, _idle) public {
+    comp = _comp;
+    stkaave = _stkaave;
+    aave = _aave;
+    idle = _idle;
+    underlying = IERC20(_underlying);
+    idleUnderlying = _idleUnderlying;
+    vault = _vault;
+    uniswapRouterV2 = _uniswap;
+    protected = true;
+
+    // set these tokens to be not salvagable
+    unsalvagableTokens[_underlying] = true;
+    unsalvagableTokens[_idleUnderlying] = true;
+    unsalvagableTokens[_comp] = true;
+    unsalvagableTokens[_stkaave] = true;
+    unsalvagableTokens[_aave] = true;
+    unsalvagableTokens[_idle] = true;
+
+    uniswapComp = [_comp, _weth, _idle];
+    uniswapAave = [_aave, _weth, _idle];
+    uniswapIdle = [_idle, _weth, _underlying];
+    referral = address(0xf00dD244228F51547f0563e60bCa65a30FBF5f7f);
+    sellComp = true;
+    sellAave = true;
+    sellIdle = true;
+    claimAllowed = true;
+
+    idleTokenHelper = IIdleTokenHelper(0x04Ce60ed10F6D2CfF3AA015fc7b950D13c113be5);
+    virtualPrice = idleTokenHelper.getRedeemPrice(idleUnderlying);
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  function setReferral(address _newRef) public onlyGovernance {
+    referral = _newRef;
+  }
+
+  /**
+  * The strategy invests by supplying the underlying token into IDLE.
+  */
+  function investAllUnderlying() public restricted updateVirtualPrice {
+    uint256 balance = underlying.balanceOf(address(this));
+    underlying.safeApprove(address(idleUnderlying), 0);
+    underlying.safeApprove(address(idleUnderlying), balance);
+    IIdleTokenV3_1(idleUnderlying).mintIdleToken(balance, true, referral);
+  }
+
+  /**
+  * Exits IDLE and transfers everything to the vault.
+  */
+  function withdrawAllToVault() external restricted updateVirtualPrice {
+    withdrawAll();
+    IERC20(address(underlying)).safeTransfer(vault, underlying.balanceOf(address(this)));
+  }
+
+  /**
+  * Withdraws all from IDLE
+  */
+  function withdrawAll() internal {
+    uint256 balance = IERC20(idleUnderlying).balanceOf(address(this));
+
+    // this automatically claims the crops
+    IIdleTokenV3_1(idleUnderlying).redeemIdleToken(balance);
+
+    liquidateComp();
+    liquidateAave();
+    liquidateIdle();
+  }
+
+  function withdrawToVault(uint256 amountUnderlying) public restricted {
+    // this method is called when the vault is missing funds
+    // we will calculate the proportion of idle LP tokens that matches
+    // the underlying amount requested
+    uint256 balanceBefore = underlying.balanceOf(address(this));
+    uint256 totalIdleLpTokens = IERC20(idleUnderlying).balanceOf(address(this));
+    uint256 totalUnderlyingBalance = totalIdleLpTokens.mul(virtualPrice).div(1e18);
+    uint256 ratio = amountUnderlying.mul(1e18).div(totalUnderlyingBalance);
+    uint256 toRedeem = totalIdleLpTokens.mul(ratio).div(1e18);
+    IIdleTokenV3_1(idleUnderlying).redeemIdleToken(toRedeem);
+    uint256 balanceAfter = underlying.balanceOf(address(this));
+    underlying.safeTransfer(vault, balanceAfter.sub(balanceBefore));
+  }
+
+  /**
+  * Withdraws all assets, liquidates COMP, and invests again in the required ratio.
+  */
+  function doHardWork() public restricted updateVirtualPrice {
+    if (claimAllowed) {
+      claim();
+    }
+    liquidateComp();
+    liquidateAave();
+    liquidateIdle();
+
+    // this updates the virtual price
+    investAllUnderlying();
+
+    // state of supply/loan will be updated by the modifier
+  }
+
+  /**
+  * Salvages a token.
+  */
+  function salvage(address recipient, address token, uint256 amount) public onlyGovernance {
+    // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens[token], "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  function claim() internal {
+    IIdleTokenV3_1(idleUnderlying).redeemIdleToken(0);
+  }
+
+  function liquidateComp() internal {
+    if (!sellComp) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(comp);
+      return;
+    }
+
+    // no profit notification, comp is liquidated to IDLE and will be notified there
+
+    uint256 compBalance = IERC20(comp).balanceOf(address(this));
+    if (compBalance > 0) {
+      emit Liquidating(address(comp), compBalance);
+      IERC20(comp).safeApprove(uniswapRouterV2, 0);
+      IERC20(comp).safeApprove(uniswapRouterV2, compBalance);
+      // we can accept 1 as the minimum because this will be called only by a trusted worker
+      IUniswapV2Router02(uniswapRouterV2).swapExactTokensForTokens(
+        compBalance, 1, uniswapComp, address(this), block.timestamp
+      );
+    }
+  }
+
+  function liquidateAave() internal {
+    if (!sellAave) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(comp);
+      return;
+    }
+
+    // no profit notification, comp is liquidated to IDLE and will be notified there
+
+    uint256 stkAaveBalance = IERC20(stkaave).balanceOf(address(this));
+    if (stkAaveBalance > 0) {
+      IStakedAave(stkaave).redeem(address(this), stkAaveBalance);
+    }
+    uint256 aaveBalance = IERC20(aave).balanceOf(address(this));
+    if (aaveBalance > 0) {
+      emit Liquidating(address(aave), aaveBalance);
+      IERC20(aave).safeApprove(uniswapRouterV2, 0);
+      IERC20(aave).safeApprove(uniswapRouterV2, aaveBalance);
+      // we can accept 1 as the minimum because this will be called only by a trusted worker
+      IUniswapV2Router02(uniswapRouterV2).swapExactTokensForTokens(
+        aaveBalance, 1, uniswapAave, address(this), block.timestamp
+      );
+    }
+  }
+
+  function liquidateIdle() internal {
+    if (!sellIdle) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(idle);
+      return;
+    }
+
+    uint256 rewardBalance = IERC20(idle).balanceOf(address(this));
+    notifyProfitInRewardToken(rewardBalance);
+
+    uint256 idleBalance = IERC20(idle).balanceOf(address(this));
+    if (idleBalance > 0) {
+      emit Liquidating(address(idle), idleBalance);
+      IERC20(idle).safeApprove(uniswapRouterV2, 0);
+      IERC20(idle).safeApprove(uniswapRouterV2, idleBalance);
+      // we can accept 1 as the minimum because this will be called only by a trusted worker
+      IUniswapV2Router02(uniswapRouterV2).swapExactTokensForTokens(
+        idleBalance, 1, uniswapIdle, address(this), block.timestamp
+      );
+    }
+  }
+
+  /**
+  * Returns the current balance. Ignores COMP that was not liquidated and invested.
+  */
+  function investedUnderlyingBalance() public view returns (uint256) {
+    // NOTE: The use of virtual price is okay for appreciating assets inside IDLE,
+    // but would be wrong and exploitable if funds were lost by IDLE, indicated by
+    // the virtualPrice being greater than the token price.
+    if (protected) {
+      require(virtualPrice <= idleTokenHelper.getRedeemPrice(idleUnderlying), "virtual price is higher than needed");
+    }
+    uint256 invested = IERC20(idleUnderlying).balanceOf(address(this)).mul(virtualPrice).div(1e18);
+    return invested.add(IERC20(underlying).balanceOf(address(this)));
+  }
+
+  function setLiquidation(bool _sellComp, bool _sellIdle, bool _claimAllowed) public onlyGovernance {
+    sellComp = _sellComp;
+    sellIdle = _sellIdle;
+    claimAllowed = _claimAllowed;
+  }
+
+  function setProtected(bool _protected) public onlyGovernance {
+    protected = _protected;
+  }
+
+  function setMultiSig(address _address) public onlyGovernance {
+    multiSig = _address;
+  }
+
+  // reward claiming by multiSig for some strategies
+  function claimReward() public onlyMultiSigOrGovernance {
+    require(allowedRewardClaimable, "reward claimable is not allowed");
+    claim();
+    uint256 idleBalance = IERC20(idle).balanceOf(address(this));
+    IERC20(idle).safeTransfer(msg.sender, idleBalance);
+    uint256 compBalance = IERC20(comp).balanceOf(address(this));
+    IERC20(comp).safeTransfer(msg.sender, compBalance);
+    uint256 stkaaveBalance = IERC20(stkaave).balanceOf(address(this));
+    IERC20(stkaave).safeTransfer(msg.sender, stkaaveBalance);
+  }
+
+  function setRewardClaimable(bool flag) public onlyGovernance {
+    allowedRewardClaimable = flag;
+  }
+}

--- a/contracts/strategies/idle/IdleFinanceStrategyClaimable.sol
+++ b/contracts/strategies/idle/IdleFinanceStrategyClaimable.sol
@@ -220,7 +220,7 @@ contract IdleFinanceStrategyClaimable is IStrategy, RewardTokenProfitNotifier {
   function liquidateAave() internal {
     if (!sellAave) {
       // Profits can be disabled for possible simplified and rapid exit
-      emit ProfitsNotCollected(comp);
+      emit ProfitsNotCollected(aave);
       return;
     }
 

--- a/contracts/strategies/idle/IdleStrategyDAIMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyDAIMainnet.sol
@@ -13,6 +13,8 @@ contract IdleStrategyDAIMainnet is IdleFinanceStrategy {
   address constant public __idleUnderlying= address(0x3fE7940616e5Bc47b0775a0dccf6237893353bB4);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -24,6 +26,8 @@ contract IdleStrategyDAIMainnet is IdleFinanceStrategy {
     __idleUnderlying,
     _vault,
     __comp,
+    __stkaave,
+    __aave,
     __idle,
     __weth,
     __uniswap

--- a/contracts/strategies/idle/IdleStrategyUSDCMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyUSDCMainnet.sol
@@ -13,6 +13,8 @@ contract IdleStrategyUSDCMainnet is IdleFinanceStrategy {
   address constant public __idleUnderlying= address(0x5274891bEC421B39D23760c04A6755eCB444797C);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -24,6 +26,8 @@ contract IdleStrategyUSDCMainnet is IdleFinanceStrategy {
     __idleUnderlying,
     _vault,
     __comp,
+    __stkaave,
+    __aave,
     __idle,
     __weth,
     __uniswap

--- a/contracts/strategies/idle/IdleStrategyUSDTMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyUSDTMainnet.sol
@@ -13,6 +13,8 @@ contract IdleStrategyUSDTMainnet is IdleFinanceStrategy {
   address constant public __idleUnderlying= address(0xF34842d05A1c888Ca02769A633DF37177415C2f8);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -24,6 +26,8 @@ contract IdleStrategyUSDTMainnet is IdleFinanceStrategy {
     __idleUnderlying,
     _vault,
     __comp,
+    __stkaave,
+    __aave,
     __idle,
     __weth,
     __uniswap

--- a/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
@@ -1,10 +1,10 @@
 pragma solidity 0.5.16;
-import "./IdleFinanceStrategy.sol";
+import "./IdleFinanceStrategyClaimable.sol";
 
 /**
 * Adds the mainnet addresses to the PickleStrategy3Pool
 */
-contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
+contract IdleStrategyWBTCMainnet is IdleFinanceStrategyClaimable {
 
   // token addresses
   address constant public __weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
@@ -20,7 +20,7 @@ contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
     address _storage,
     address _vault
   )
-  IdleFinanceStrategy(
+  IdleFinanceStrategyClaimable(
     _storage,
     __wbtc,
     __idleUnderlying,

--- a/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
@@ -13,6 +13,8 @@ contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
   address constant public __idleUnderlying= address(0x8C81121B15197fA0eEaEE1DC75533419DcfD3151);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -24,6 +26,8 @@ contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
     __idleUnderlying,
     _vault,
     __comp,
+    __stkaave,
+    __aave,
     __idle,
     __weth,
     __uniswap

--- a/contracts/strategies/idle/interface/IStakedAave.sol
+++ b/contracts/strategies/idle/interface/IStakedAave.sol
@@ -10,4 +10,8 @@ function redeem(address to, uint256 amount) external;
 function cooldown() external;
 
 function claimRewards(address to, uint256 amount) external;
+function COOLDOWN_SECONDS() external view returns(uint256);
+function UNSTAKE_WINDOW() external view returns(uint256);
+function stakersCooldowns(address input) external view returns(uint256);
+function stakerRewardsToClaim(address input) external view returns(uint256);
 }

--- a/contracts/strategies/idle/interface/IStakedAave.sol
+++ b/contracts/strategies/idle/interface/IStakedAave.sol
@@ -1,0 +1,13 @@
+
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.5.16;
+
+interface IStakedAave {
+function stake(address to, uint256 amount) external;
+
+function redeem(address to, uint256 amount) external;
+
+function cooldown() external;
+
+function claimRewards(address to, uint256 amount) external;
+}

--- a/test/curve/tbtc-claimable.js
+++ b/test/curve/tbtc-claimable.js
@@ -1,0 +1,109 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("CRVStrategyTBTCMixedMainnet");
+
+//Test developed at blockNumber 11997700
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Curve TBTC (claimable)", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  // block number: 12450065
+  let underlyingWhale = "0x32d2d8a08e29668492724b83d81c750123b6b905";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+  let multiSig;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+    multiSig = "0xF49440C1F012d041802b25A73e5B0B9166a75c02";
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale, multiSig]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    await strategy.setSellFloor(0, {from:governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      await strategy.setSell(false, {from: governance});
+      await strategy.setRewardClaimable(true, {from: governance});
+      await controller.doHardWork(vault.address, { from: governance });
+
+      let reward = await IERC20.at("0xD533a949740bb3306d119CC777fa900bA034cd52");
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        let rewardBalanceBefore = new BigNumber(await reward.balanceOf(multiSig));
+        await strategy.claimReward({from: multiSig});
+        let rewardBalanceAfter = new BigNumber(await reward.balanceOf(multiSig));
+
+        console.log("rewardBalanceBefore: ", rewardBalanceBefore.toFixed());
+        console.log("rewardBalanceAfter: ", rewardBalanceAfter.toFixed());
+        console.log("diff: ", (rewardBalanceAfter.minus(rewardBalanceBefore)).toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(farmerBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+
+      console.log("earned!");
+
+    });
+  });
+});

--- a/test/curve/tbtc.js
+++ b/test/curve/tbtc.js
@@ -1,0 +1,100 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("CRVStrategyTBTCMixedMainnet");
+
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Curve TBTC", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup blockNumber = 12450065
+  let underlyingWhale = "0x32d2d8a08e29668492724b83d81c750123b6b905";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x64eda51d3Ad40D56b9dFc5554E06F94e1Dd786Fd");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed()/oldSharePrice.toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(farmerBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      console.log("earned!");
+
+    });
+  });
+});

--- a/test/idle/wbtc-claim.js
+++ b/test/idle/wbtc-claim.js
@@ -1,0 +1,136 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const IdleStrategyWBTCMainnet = artifacts.require("IdleStrategyWBTCMainnet");
+const IVault = artifacts.require("IVault");
+
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet IDLE WBTC Claimable", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup, block number: 12323239
+  let underlyingWhale = "0x701bd63938518d7db7e0f00945110c80c67df532";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    multiSig = "0xF49440C1F012d041802b25A73e5B0B9166a75c02";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale, multiSig]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": "0x5d9d25c7C457dD82fc8668FFC6B9746b674d4EcB",
+      "strategyArtifact": IdleStrategyWBTCMainnet,
+      "announceStrategy": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      await controller.doHardWork(vault.address, { from: governance });
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+
+      // Not selling, so doHardWork wouldn't sell rewards
+      await strategy.setLiquidation(false, false, true, {from: governance});
+
+      await strategy.setRewardClaimable(true, {from: governance});
+
+      oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+      await controller.doHardWork(vault.address, { from: governance });
+      newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+      let idle = await IERC20.at("0x875773784Af8135eA0ef43b5a374AaD105c5D39e");
+      let comp = await IERC20.at("0xc00e94Cb662C3520282E6f5717214004A7f26888");
+      let stkaave = await IERC20.at("0x4da27a545c0c5B758a6BA100e3a049001de870f5");
+
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        let idleBalanceBefore = new BigNumber(await idle.balanceOf(multiSig));
+        let compBalanceBefore = new BigNumber(await comp.balanceOf(multiSig));
+        let stkaaveBalanceBefore = new BigNumber(await stkaave.balanceOf(multiSig));
+        await strategy.claimReward({from: multiSig});
+        let idleBalanceAfter = new BigNumber(await idle.balanceOf(multiSig));
+        let compBalanceAfter = new BigNumber(await comp.balanceOf(multiSig));
+        let stkaaveBalanceAfter = new BigNumber(await stkaave.balanceOf(multiSig));
+
+        console.log("idleBalanceBefore: ", idleBalanceBefore.toFixed());
+        console.log("idleBalanceAfter: ", idleBalanceAfter.toFixed());
+        console.log("idle diff: ", (idleBalanceAfter.minus(idleBalanceBefore)).toFixed());
+
+        console.log("compBalanceBefore: ", compBalanceBefore.toFixed());
+        console.log("compBalanceAfter: ", compBalanceAfter.toFixed());
+        console.log("comp diff: ", (compBalanceAfter.minus(compBalanceBefore)).toFixed());
+
+        console.log("stkaaveBalanceBefore: ", stkaaveBalanceBefore.toFixed());
+        console.log("stkaaveBalanceAfter: ", stkaaveBalanceAfter.toFixed());
+        console.log("stkaave diff: ", (stkaaveBalanceAfter.minus(stkaaveBalanceBefore)).toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      const vaultBalance = new BigNumber(await vault.balanceOf(farmer1));
+      console.log("vaultBalance: ", vaultBalance.toFixed());
+
+      await vault.withdraw(vaultBalance.toFixed(), { from: farmer1 });
+
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      console.log("farmerOldBalance: ", farmerOldBalance.toFixed());
+      console.log("farmerNewBalance: ", farmerNewBalance.toFixed());
+      Utils.assertBNGte(farmerNewBalance, farmerOldBalance);
+      console.log("got the same amount back");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/sushi/ust-weth-claim.js
+++ b/test/sushi/ust-weth-claim.js
@@ -1,0 +1,124 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("SushiStrategyMainnet_UST_WETH");
+
+//This test was developed at blockNumber 12446945
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Sushi: UST:WETH", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0xA046a8660E66d178eE07ec97c585eeb6aa18c26C";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x8B00eE8606CC70c2dce68dea0CEfe632CCA0fB7b");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    multiSig = "0xF49440C1F012d041802b25A73e5B0B9166a75c02";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale, multiSig]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance
+    });
+
+    // Else sellfloor will not be reached
+    await strategy.setSellFloor(0, {from:governance});
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let oldSharePrice;
+      let newSharePrice;
+
+      // Not selling, so doHardWork wouldn't sell rewards
+      await strategy.setSell(false, {from: governance});
+
+      await strategy.setRewardClaimable(true, {from: governance});
+
+      oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+      await controller.doHardWork(vault.address, { from: governance });
+      newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+      let reward = await IERC20.at("0x6B3595068778DD592e39A122f4f5a5cF09C90fE2");
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        let blocksPerHour = 2400;
+        let rewardBalanceBefore = new BigNumber(await reward.balanceOf(multiSig));
+        await strategy.claimReward({from: multiSig});
+        let rewardBalanceAfter = new BigNumber(await reward.balanceOf(multiSig));
+
+        console.log("rewardBalanceBefore: ", rewardBalanceBefore.toFixed());
+        console.log("rewardBalanceAfter: ", rewardBalanceAfter.toFixed());
+        console.log("diff: ", (rewardBalanceAfter.minus(rewardBalanceBefore)).toFixed());
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      const vaultBalance = new BigNumber(await vault.balanceOf(farmer1));
+      console.log("vaultBalance: ", vaultBalance.toFixed());
+
+      await vault.withdraw(vaultBalance.toFixed(), { from: farmer1 });
+
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      console.log("farmerOldBalance: ", farmerOldBalance.toFixed());
+      console.log("farmerNewBalance: ", farmerNewBalance.toFixed());
+      Utils.assertBNEq(farmerNewBalance, farmerOldBalance);
+      console.log("got the same amount back");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});


### PR DESCRIPTION
Added the requested claimable strategies and made some general updates. Included in this PR:

- Include stkAave liquidation logic in Idle strategies.
- Create `IdleFinanceStrategyClaimable` and update `IdleStrategyWBTCMainnet` to be claimable.
- Update the reward claim logic in all MasterChef strategies, as discussed personally. 
- Update `MasterChefStrategy` and `SushiStrategyMainnet_UST_WETH` to be claimable.
- Add and update the TBTC strategy. (I took the strategy from etherscan as it was not included in the repo. It contained very old logic, so I updated it and removed the logic to liquidate KEEP rewards, as these have stopped.)
- Create `CRVStrategyTBTCMixedClaimable` and update `CRVStrategyTBTCMixedMainnet` to be claimable.

Tests for all new strategies and functionalities are included.