### PR TITLE
Add instructions for out-of-memory issues when running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ All tests are located under the `test` folder.
     accounts that are no longer such at the most recent block, or for time-sensitive activities like migrations.
     In addition, specifying block number speeds up tests due to caching.
 
-1. Run `npx hardhat test [test file location]`: `npx hardhat test ./test/1inch/eth-dai.js`. This will produce the following output:
+1. Run `npx hardhat test [test file location]`: `npx hardhat test ./test/1inch/eth-dai.js` (if for some reason the NodeJS heap runs out of memory, make sure to explicitly increase its size via `export NODE_OPTIONS=--max_old_space_size=4096`). This will produce the following output:
     ```
     Mainnet ETH/DAI
     Impersonating...


### PR DESCRIPTION
When running tests locally I kept getting `Allocation failed - JavaScript heap out of memory` errors. I managed to work around them by explicitly increasing the heap size of NodeJS via `export NODE_OPTIONS=--max_old_space_size=4096`. Others might run into this as well so maybe it's worthwhile to add some instructions on how to overcome it.