### PR TITLE
Update for EURS liquidation

### DIFF
--- a/contracts/strategies/convex/ConvexStrategy2Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy2Token.sol
@@ -13,7 +13,6 @@ import "./interface/IBooster.sol";
 import "./interface/IBaseRewardPool.sol";
 import "../../base/interface/curve/ICurveDeposit_2token.sol";
 
-
 contract ConvexStrategy2Token is IStrategy, BaseUpgradeableStrategy {
 
   using SafeMath for uint256;
@@ -173,13 +172,14 @@ contract ConvexStrategy2Token is IStrategy, BaseUpgradeableStrategy {
     _setPausedInvesting(false);
   }
 
-  function setDepositLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setDepositLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[0] == weth, "Path should start with WETH");
     require(_route[_route.length-1] == depositToken(), "Path should end with depositToken");
     WETH2deposit = _route;
+    useUni[_route[_route.length-1]] = _useUni;
   }
 
-  function setRewardLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setRewardLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[_route.length-1] == weth, "Path should end with WETH");
     bool isReward = false;
     for(uint256 i = 0; i < rewardTokens.length; i++){
@@ -189,13 +189,15 @@ contract ConvexStrategy2Token is IStrategy, BaseUpgradeableStrategy {
     }
     require(isReward, "Path should start with a rewardToken");
     reward2WETH[_route[0]] = _route;
+    useUni[_route[0]] = _useUni;
   }
 
-  function addRewardToken(address _token, address[] memory _path2WETH) public onlyGovernance {
+  function addRewardToken(address _token, address[] memory _path2WETH, bool _useUni) public onlyGovernance {
     require(_path2WETH[_path2WETH.length-1] == weth, "Path should end with WETH");
     require(_path2WETH[0] == _token, "Path should start with rewardToken");
     rewardTokens.push(_token);
     reward2WETH[_token] = _path2WETH;
+    useUni[_token] = _useUni;
   }
 
   // We assume that all the tradings can be done on Sushiswap

--- a/contracts/strategies/convex/ConvexStrategy3Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy3Token.sol
@@ -173,13 +173,14 @@ contract ConvexStrategy3Token is IStrategy, BaseUpgradeableStrategy {
     _setPausedInvesting(false);
   }
 
-  function setDepositLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setDepositLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[0] == weth, "Path should start with WETH");
     require(_route[_route.length-1] == depositToken(), "Path should end with depositToken");
     WETH2deposit = _route;
+    useUni[_route[_route.length-1]] = _useUni;
   }
 
-  function setRewardLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setRewardLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[_route.length-1] == weth, "Path should end with WETH");
     bool isReward = false;
     for(uint256 i = 0; i < rewardTokens.length; i++){
@@ -189,13 +190,15 @@ contract ConvexStrategy3Token is IStrategy, BaseUpgradeableStrategy {
     }
     require(isReward, "Path should start with a rewardToken");
     reward2WETH[_route[0]] = _route;
+    useUni[_route[0]] = _useUni;
   }
 
-  function addRewardToken(address _token, address[] memory _path2WETH) public onlyGovernance {
+  function addRewardToken(address _token, address[] memory _path2WETH, bool _useUni) public onlyGovernance {
     require(_path2WETH[_path2WETH.length-1] == weth, "Path should end with WETH");
     require(_path2WETH[0] == _token, "Path should start with rewardToken");
     rewardTokens.push(_token);
     reward2WETH[_token] = _path2WETH;
+    useUni[_token] = _useUni;
   }
 
   // We assume that all the tradings can be done on Sushiswap

--- a/contracts/strategies/convex/ConvexStrategy4Token.sol
+++ b/contracts/strategies/convex/ConvexStrategy4Token.sol
@@ -173,13 +173,14 @@ contract ConvexStrategy4Token is IStrategy, BaseUpgradeableStrategy {
     _setPausedInvesting(false);
   }
 
-  function setDepositLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setDepositLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[0] == weth, "Path should start with WETH");
     require(_route[_route.length-1] == depositToken(), "Path should end with depositToken");
     WETH2deposit = _route;
+    useUni[_route[_route.length-1]] = _useUni;
   }
 
-  function setRewardLiquidationPath(address [] memory _route) public onlyGovernance {
+  function setRewardLiquidationPath(address [] memory _route, bool _useUni) public onlyGovernance {
     require(_route[_route.length-1] == weth, "Path should end with WETH");
     bool isReward = false;
     for(uint256 i = 0; i < rewardTokens.length; i++){
@@ -189,13 +190,15 @@ contract ConvexStrategy4Token is IStrategy, BaseUpgradeableStrategy {
     }
     require(isReward, "Path should start with a rewardToken");
     reward2WETH[_route[0]] = _route;
+    useUni[_route[0]] = _useUni;
   }
 
-  function addRewardToken(address _token, address[] memory _path2WETH) public onlyGovernance {
+  function addRewardToken(address _token, address[] memory _path2WETH, bool _useUni) public onlyGovernance {
     require(_path2WETH[_path2WETH.length-1] == weth, "Path should end with WETH");
     require(_path2WETH[0] == _token, "Path should start with rewardToken");
     rewardTokens.push(_token);
     reward2WETH[_token] = _path2WETH;
+    useUni[_token] = _useUni;
   }
 
   // We assume that all the tradings can be done on Sushiswap

--- a/contracts/strategies/convex/ConvexStrategyEURSMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyEURSMainnet.sol
@@ -35,6 +35,6 @@ contract ConvexStrategyEURSMainnet is ConvexStrategy2Token {
     rewardTokens = [crv, cvx];
     useUni[crv] = false;
     useUni[cvx] = false;
-    useUni[eurs] = true;
+    useUni[eurs] = false;
   }
 }

--- a/test/convex/eurs.js
+++ b/test/convex/eurs.js
@@ -10,7 +10,7 @@ const IBooster = artifacts.require("IBooster");
 
 const Strategy = artifacts.require("ConvexStrategyEURSMainnet");
 
-//This test was developed at blockNumber 12555215
+//This test was developed at blockNumber 12727685
 
 // Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
 describe("Mainnet Convex EURS", function() {
@@ -20,7 +20,7 @@ describe("Mainnet Convex EURS", function() {
   let underlying;
 
   // external setup
-  let underlyingWhale = "0xe787949d68C28F47A49eeB805ec8480279272563";
+  let underlyingWhale = "0x8a08aD6DA1e8b142C9622DDFEB6ad8d6511d724F";
   let booster;
 
   // parties in the protocol


### PR DESCRIPTION
EURS was getting liquidated through UNI-V2, but liquidity dried up there. Biggest liquidity is now in UNI-V3. Sushi has a $2.5m USDC-EURS pool. Easiest is to switch to the Sushi pool, which should be large enough for our liquidations.

Made new version of the strategy. The current strategy does allow to update the liquidation path, but not the `useUni` bool. Update allows this. I tested it with upgrading the old strategy proxy and updating the path, but this did not seem to work, the bool keeps set to `true` and liquidations keep going through Uni. So I think the new strategy has to be released with a new proxy.