### PR TITLE
Idle updates

### DIFF
--- a/contracts/strategies/idle/IdleStrategyDAIMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyDAIMainnet.sol
@@ -7,12 +7,12 @@ import "./IdleFinanceStrategy.sol";
 contract IdleStrategyDAIMainnet is IdleFinanceStrategy {
 
   // token addresses
-  address constant public __weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
   address constant public __dai = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
-  address constant public __uniswap = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
   address constant public __idleUnderlying= address(0x3fE7940616e5Bc47b0775a0dccf6237893353bB4);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -23,11 +23,21 @@ contract IdleStrategyDAIMainnet is IdleFinanceStrategy {
     __dai,
     __idleUnderlying,
     _vault,
-    __comp,
-    __idle,
-    __weth,
-    __uniswap
+    __stkaave
   )
   public {
+    rewardTokens = [__comp, __idle, __aave];
+    reward2WETH[__comp] = [__comp, weth];
+    reward2WETH[__idle] = [__idle, weth];
+    reward2WETH[__aave] = [__aave, weth];
+    WETH2underlying = [weth, __dai];
+    sell[__comp] = true;
+    sell[__idle] = true;
+    sell[__aave] = true;
+    useUni[__comp] = false;
+    useUni[__idle] = false;
+    useUni[__aave] = false;
+    useUni[__dai] = false;
+    allowedRewardClaimable = true;
   }
 }

--- a/contracts/strategies/idle/IdleStrategyUSDCMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyUSDCMainnet.sol
@@ -7,12 +7,12 @@ import "./IdleFinanceStrategy.sol";
 contract IdleStrategyUSDCMainnet is IdleFinanceStrategy {
 
   // token addresses
-  address constant public __weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
   address constant public __usdc = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
-  address constant public __uniswap = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
   address constant public __idleUnderlying= address(0x5274891bEC421B39D23760c04A6755eCB444797C);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -23,11 +23,21 @@ contract IdleStrategyUSDCMainnet is IdleFinanceStrategy {
     __usdc,
     __idleUnderlying,
     _vault,
-    __comp,
-    __idle,
-    __weth,
-    __uniswap
+    __stkaave
   )
   public {
+    rewardTokens = [__comp, __idle, __aave];
+    reward2WETH[__comp] = [__comp, weth];
+    reward2WETH[__idle] = [__idle, weth];
+    reward2WETH[__aave] = [__aave, weth];
+    WETH2underlying = [weth, __usdc];
+    sell[__comp] = true;
+    sell[__idle] = true;
+    sell[__aave] = true;
+    useUni[__comp] = false;
+    useUni[__idle] = false;
+    useUni[__aave] = false;
+    useUni[__usdc] = false;
+    allowedRewardClaimable = true;
   }
 }

--- a/contracts/strategies/idle/IdleStrategyUSDTMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyUSDTMainnet.sol
@@ -7,12 +7,12 @@ import "./IdleFinanceStrategy.sol";
 contract IdleStrategyUSDTMainnet is IdleFinanceStrategy {
 
   // token addresses
-  address constant public __weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
   address constant public __usdt = address(0xdAC17F958D2ee523a2206206994597C13D831ec7);
-  address constant public __uniswap = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
   address constant public __idleUnderlying= address(0xF34842d05A1c888Ca02769A633DF37177415C2f8);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -23,11 +23,21 @@ contract IdleStrategyUSDTMainnet is IdleFinanceStrategy {
     __usdt,
     __idleUnderlying,
     _vault,
-    __comp,
-    __idle,
-    __weth,
-    __uniswap
+    __stkaave
   )
   public {
+    rewardTokens = [__comp, __idle, __aave];
+    reward2WETH[__comp] = [__comp, weth];
+    reward2WETH[__idle] = [__idle, weth];
+    reward2WETH[__aave] = [__aave, weth];
+    WETH2underlying = [weth, __usdt];
+    sell[__comp] = true;
+    sell[__idle] = true;
+    sell[__aave] = true;
+    useUni[__comp] = false;
+    useUni[__idle] = false;
+    useUni[__aave] = false;
+    useUni[__usdt] = false;
+    allowedRewardClaimable = true;
   }
 }

--- a/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
+++ b/contracts/strategies/idle/IdleStrategyWBTCMainnet.sol
@@ -7,12 +7,12 @@ import "./IdleFinanceStrategy.sol";
 contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
 
   // token addresses
-  address constant public __weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
   address constant public __wbtc = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
-  address constant public __uniswap = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
   address constant public __idleUnderlying= address(0x8C81121B15197fA0eEaEE1DC75533419DcfD3151);
   address constant public __comp = address(0xc00e94Cb662C3520282E6f5717214004A7f26888);
   address constant public __idle = address(0x875773784Af8135eA0ef43b5a374AaD105c5D39e);
+  address constant public __stkaave = address(0x4da27a545c0c5B758a6BA100e3a049001de870f5);
+  address constant public __aave = address(0x7Fc66500c84A76Ad7e9c93437bFc5Ac33E2DDaE9);
 
   constructor(
     address _storage,
@@ -23,11 +23,21 @@ contract IdleStrategyWBTCMainnet is IdleFinanceStrategy {
     __wbtc,
     __idleUnderlying,
     _vault,
-    __comp,
-    __idle,
-    __weth,
-    __uniswap
+    __stkaave
   )
   public {
+    rewardTokens = [__comp, __idle, __aave];
+    reward2WETH[__comp] = [__comp, weth];
+    reward2WETH[__idle] = [__idle, weth];
+    reward2WETH[__aave] = [__aave, weth];
+    WETH2underlying = [weth, __wbtc];
+    sell[__comp] = true;
+    sell[__idle] = true;
+    sell[__aave] = true;
+    useUni[__comp] = false;
+    useUni[__idle] = false;
+    useUni[__aave] = false;
+    useUni[__wbtc] = false;
+    allowedRewardClaimable = true;
   }
 }

--- a/contracts/strategies/idle/interface/IStakedAave.sol
+++ b/contracts/strategies/idle/interface/IStakedAave.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.5.16;
+
+interface IStakedAave {
+function stake(address to, uint256 amount) external;
+
+function redeem(address to, uint256 amount) external;
+
+function cooldown() external;
+
+function claimRewards(address to, uint256 amount) external;
+function COOLDOWN_SECONDS() external view returns(uint256);
+function UNSTAKE_WINDOW() external view returns(uint256);
+function stakersCooldowns(address input) external view returns(uint256);
+function stakerRewardsToClaim(address input) external view returns(uint256);
+}

--- a/test/idle/dai.js
+++ b/test/idle/dai.js
@@ -17,7 +17,7 @@ describe("Mainnet IDLE DAI", function() {
   // external contracts
   let underlying;
 
-  // external setup, block number: 12323239
+  // external setup, block number: 12882710
   let underlyingWhale = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503";
 
   // parties in the protocol
@@ -42,7 +42,7 @@ describe("Mainnet IDLE DAI", function() {
     // Give whale some ether to make sure the following actions are good
     await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
 
-    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    farmerBalance = "1000000" + "000000000000000000";
     await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
   }
 
@@ -81,14 +81,14 @@ describe("Mainnet IDLE DAI", function() {
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
         console.log("loop ", i);
-        let blocksPerHour = 240;
+        let blocksPerHour = 2400;
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
         await vault.doHardWork({ from: governance });
         newSharePrice = new BigNumber(await vault.getPricePerFullShare());
 
         console.log("old shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
-        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+        console.log("growth: ", newSharePrice.toFixed()/oldSharePrice.toFixed());
 
         await Utils.advanceNBlock(blocksPerHour);
       }

--- a/test/idle/usdc.js
+++ b/test/idle/usdc.js
@@ -18,7 +18,7 @@ describe("Mainnet IDLE USDC", function() {
   // external contracts
   let underlying;
 
-  // external setup, block number: 12323239
+  // external setup, block number: 12882710
   let underlyingWhale = "0xAe2D4617c862309A3d75A0fFB358c7a5009c673F";
 
   // parties in the protocol
@@ -43,7 +43,7 @@ describe("Mainnet IDLE USDC", function() {
     // Give whale some ether to make sure the following actions are good
     await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
 
-    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    farmerBalance = "1000000" + "000000";
     await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
   }
 
@@ -82,14 +82,14 @@ describe("Mainnet IDLE USDC", function() {
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
         console.log("loop ", i);
-        let blocksPerHour = 240;
+        let blocksPerHour = 2400;
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
         await vault.doHardWork({ from: governance });
         newSharePrice = new BigNumber(await vault.getPricePerFullShare());
 
         console.log("old shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
-        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+        console.log("growth: ", newSharePrice.toFixed()/oldSharePrice.toFixed());
 
         await Utils.advanceNBlock(blocksPerHour);
       }

--- a/test/idle/usdt.js
+++ b/test/idle/usdt.js
@@ -18,7 +18,7 @@ describe("Mainnet IDLE USDT", function() {
   // external contracts
   let underlying;
 
-  // external setup, block number: 12323239
+  // external setup, block number: 12882710
   let underlyingWhale = "0x47ac0fb4f2d84898e4d9e7b4dab3c24507a6d503";
 
   // parties in the protocol
@@ -43,7 +43,7 @@ describe("Mainnet IDLE USDT", function() {
     // Give whale some ether to make sure the following actions are good
     await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
 
-    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    farmerBalance = "1000000" + "000000";
     await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
   }
 
@@ -82,14 +82,14 @@ describe("Mainnet IDLE USDT", function() {
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
         console.log("loop ", i);
-        let blocksPerHour = 240;
+        let blocksPerHour = 2400;
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
         await vault.doHardWork({ from: governance });
         newSharePrice = new BigNumber(await vault.getPricePerFullShare());
 
         console.log("old shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
-        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+        console.log("growth: ", newSharePrice.toFixed()/oldSharePrice.toFixed());
 
         await Utils.advanceNBlock(blocksPerHour);
       }

--- a/test/idle/wbtc.js
+++ b/test/idle/wbtc.js
@@ -18,8 +18,8 @@ describe("Mainnet IDLE WBTC", function() {
   // external contracts
   let underlying;
 
-  // external setup, block number: 12323239
-  let underlyingWhale = "0x701bd63938518d7db7e0f00945110c80c67df532";
+  // external setup, block number: 12882710
+  let underlyingWhale = "0x2FAF487A4414Fe77e2327F0bf4AE2a264a776AD2";
 
   // parties in the protocol
   let governance;
@@ -43,7 +43,7 @@ describe("Mainnet IDLE WBTC", function() {
     // Give whale some ether to make sure the following actions are good
     await send.ether(etherGiver, underlyingWhale, "1" + "000000000000000000");
 
-    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    farmerBalance = "30" + "00000000";
     await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
   }
 
@@ -82,14 +82,14 @@ describe("Mainnet IDLE WBTC", function() {
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
         console.log("loop ", i);
-        let blocksPerHour = 240;
+        let blocksPerHour = 2400;
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
         await vault.doHardWork({ from: governance });
         newSharePrice = new BigNumber(await vault.getPricePerFullShare());
 
         console.log("old shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
-        console.log("growth: ", (newSharePrice.dividedBy(oldSharePrice)).toFixed());
+        console.log("growth: ", newSharePrice.toFixed()/oldSharePrice.toFixed());
 
         await Utils.advanceNBlock(blocksPerHour);
       }


### PR DESCRIPTION
IDLE strategy updated. Includes logic to claim the Aave rewards for stkAave, and makes stkAave claimable to the msig. 

Also changed the general structure a bit to make liquidation more efficient. All swaps now happen on Sushi, where especially comp and idle have much larger LPs.

Let me know if there's any questions or remarks!