### PR TITLE
Strategy upgrade to claim vested Comfi

### DIFF
--- a/contracts/strategies/complifi/ComplifiStrategyClaim.sol
+++ b/contracts/strategies/complifi/ComplifiStrategyClaim.sol
@@ -1,0 +1,388 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../base/interface/IStrategy.sol";
+import "../../base/interface/IVault.sol";
+import "../../base/upgradability/BaseUpgradeableStrategy.sol";
+import "./interfaces/ILiquidityMining.sol";
+import "../../base/interface/uniswap/IUniswapV2Pair.sol";
+
+contract ComplifiStrategyClaim is IStrategy, BaseUpgradeableStrategy {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant uniswapRouterV2 = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+  address public constant sushiswapRouterV2 = address(0xd9e1cE17f2641f24aE83637ab66a2cca9C378B9F);
+
+  // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+  bytes32 internal constant _POOLID_SLOT = 0x3fd729bfa2e28b7806b03a6e014729f59477b530f995be4d51defc9dad94810b;
+  bytes32 internal constant _USE_UNI_SLOT = 0x1132c1de5e5b6f1c4c7726265ddcf1f4ae2a9ecf258a0002de174248ecbf2c7a;
+  bytes32 internal constant _IS_LP_ASSET_SLOT = 0xc2f3dabf55b1bdda20d5cf5fcba9ba765dfc7c9dbaf28674ce46d43d60d58768;
+  bytes32 internal constant _MULTISIG_SLOT = 0x3e9de78b54c338efbc04e3a091b87dc7efb5d7024738302c548fc59fba1c34e6;
+
+  // this would be reset on each upgrade
+  mapping (address => address[]) public uniswapRoutes;
+
+  modifier onlyMultiSigOrGovernance() {
+    require(msg.sender == multiSig() || msg.sender == governance(), "The sender has to be multiSig or governance");
+    _;
+  }
+
+  constructor() public BaseUpgradeableStrategy() {
+    assert(_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.poolId")) - 1));
+    assert(_USE_UNI_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.useUni")) - 1));
+    assert(_IS_LP_ASSET_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.isLpAsset")) - 1));
+    assert(_MULTISIG_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.multiSig")) - 1));
+  }
+
+  function initializeStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    address _rewardToken,
+    uint256 _poolID,
+    bool _isLpAsset,
+    bool _useUni
+  ) public initializer {
+
+    BaseUpgradeableStrategy.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _rewardPool,
+      _rewardToken,
+      300, // profit sharing numerator
+      1000, // profit sharing denominator
+      true, // sell
+      1e18, // sell floor
+      12 hours // implementation change delay
+    );
+
+    address _lpt;
+    (_lpt,,,) = ILiquidityMining(rewardPool()).poolInfo(_poolID);
+    require(_lpt == underlying(), "Pool Info does not match underlying");
+    _setPoolId(_poolID);
+
+    if (_isLpAsset) {
+      address uniLPComponentToken0 = IUniswapV2Pair(underlying()).token0();
+      address uniLPComponentToken1 = IUniswapV2Pair(underlying()).token1();
+
+      // these would be required to be initialized separately by governance
+      uniswapRoutes[uniLPComponentToken0] = new address[](0);
+      uniswapRoutes[uniLPComponentToken1] = new address[](0);
+    } else {
+      uniswapRoutes[underlying()] = new address[](0);
+    }
+
+    setBoolean(_USE_UNI_SLOT, _useUni);
+    setBoolean(_IS_LP_ASSET_SLOT, _isLpAsset);
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  function rewardPoolBalance() internal view returns (uint256 bal) {
+      (bal,) = ILiquidityMining(rewardPool()).userPoolInfo(poolId(), address(this));
+  }
+
+  function exitRewardPool() internal {
+      uint256 bal = rewardPoolBalance();
+      if (bal != 0) {
+          ILiquidityMining(rewardPool()).withdraw(poolId(), bal);
+      }
+  }
+
+  function emergencyExitRewardPool() internal {
+      uint256 bal = rewardPoolBalance();
+      if (bal != 0) {
+          ILiquidityMining(rewardPool()).withdrawEmergency(poolId());
+      }
+  }
+
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying());
+  }
+
+  function enterRewardPool() internal {
+    uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+    IERC20(underlying()).safeApprove(rewardPool(), 0);
+    IERC20(underlying()).safeApprove(rewardPool(), entireBalance);
+    ILiquidityMining(rewardPool()).deposit(poolId(), entireBalance);
+  }
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  function setLiquidationPath(address _token, address [] memory _route) public onlyGovernance {
+    uniswapRoutes[_token] = _route;
+  }
+
+  // We assume that all the tradings can be done on Uniswap
+  function _liquidateReward() internal {
+    uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+    if (!sell() || rewardBalance < sellFloor()) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(sell(), rewardBalance < sellFloor());
+      return;
+    }
+
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+
+    if (remainingRewardBalance == 0) {
+      return;
+    }
+
+    address routerV2;
+    if(useUni()) {
+      routerV2 = uniswapRouterV2;
+    } else {
+      routerV2 = sushiswapRouterV2;
+    }
+
+    // allow Uniswap to sell our reward
+    IERC20(rewardToken()).safeApprove(routerV2, 0);
+    IERC20(rewardToken()).safeApprove(routerV2, remainingRewardBalance);
+
+    // we can accept 1 as minimum because this is called only by a trusted role
+    uint256 amountOutMin = 1;
+
+    if (isLpAsset()) {
+      address uniLPComponentToken0 = IUniswapV2Pair(underlying()).token0();
+      address uniLPComponentToken1 = IUniswapV2Pair(underlying()).token1();
+
+      uint256 toToken0 = remainingRewardBalance.div(2);
+      uint256 toToken1 = remainingRewardBalance.sub(toToken0);
+
+      uint256 token0Amount;
+
+      if (uniswapRoutes[uniLPComponentToken0].length > 1) {
+        // if we need to liquidate the token0
+        IUniswapV2Router02(routerV2).swapExactTokensForTokens(
+          toToken0,
+          amountOutMin,
+          uniswapRoutes[uniLPComponentToken0],
+          address(this),
+          block.timestamp
+        );
+        token0Amount = IERC20(uniLPComponentToken0).balanceOf(address(this));
+      } else {
+        // otherwise we assme token0 is the reward token itself
+        token0Amount = toToken0;
+      }
+
+      uint256 token1Amount;
+
+      if (uniswapRoutes[uniLPComponentToken1].length > 1) {
+        // sell reward token to token1
+        IUniswapV2Router02(routerV2).swapExactTokensForTokens(
+          toToken1,
+          amountOutMin,
+          uniswapRoutes[uniLPComponentToken1],
+          address(this),
+          block.timestamp
+        );
+        token1Amount = IERC20(uniLPComponentToken1).balanceOf(address(this));
+      } else {
+        token1Amount = toToken1;
+      }
+
+      // provide token1 and token2 to SUSHI
+      IERC20(uniLPComponentToken0).safeApprove(routerV2, 0);
+      IERC20(uniLPComponentToken0).safeApprove(routerV2, token0Amount);
+
+      IERC20(uniLPComponentToken1).safeApprove(routerV2, 0);
+      IERC20(uniLPComponentToken1).safeApprove(routerV2, token1Amount);
+
+      // we provide liquidity to sushi
+      uint256 liquidity;
+      (,,liquidity) = IUniswapV2Router02(routerV2).addLiquidity(
+        uniLPComponentToken0,
+        uniLPComponentToken1,
+        token0Amount,
+        token1Amount,
+        1,  // we are willing to take whatever the pair gives us
+        1,  // we are willing to take whatever the pair gives us
+        address(this),
+        block.timestamp
+      );
+    } else {
+      IUniswapV2Router02(routerV2).swapExactTokensForTokens(
+        remainingRewardBalance,
+        amountOutMin,
+        uniswapRoutes[underlying()],
+        address(this),
+        block.timestamp
+      );
+    }
+  }
+
+  /*
+  *   Stakes everything the strategy holds into the reward pool
+  */
+  function investAllUnderlying() internal onlyNotPausedInvesting {
+    // this check is needed, because most of the SNX reward pools will revert if
+    // you try to stake(0).
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      enterRewardPool();
+    }
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    if (address(rewardPool()) != address(0)) {
+      exitRewardPool();
+    }
+    ILiquidityMining(rewardPool()).claim();
+    _liquidateReward();
+    IERC20(underlying()).safeTransfer(vault(), IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawToVault(uint256 amount) public restricted {
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+
+    if(amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdraw = amount.sub(entireBalance);
+      uint256 toWithdraw = Math.min(rewardPoolBalance(), needToWithdraw);
+      ILiquidityMining(rewardPool()).withdraw(poolId(), toWithdraw);
+    }
+
+    IERC20(underlying()).safeTransfer(vault(), amount);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    if (rewardPool() == address(0)) {
+      return IERC20(underlying()).balanceOf(address(this));
+    }
+    // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+    // both are in the units of "underlying"
+    // The second part is needed because there is the emergency exit mechanism
+    // which would break the assumption that all the funds are always inside of the reward pool
+    return rewardPoolBalance().add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(token), "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  *
+  *   Note that although `onlyNotPausedInvesting` is not added here,
+  *   calling `investAllUnderlying()` affectively blocks the usage of `doHardWork`
+  *   when the investing is being paused by governance.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    ILiquidityMining(rewardPool()).claim();
+    _liquidateReward();
+    investAllUnderlying();
+  }
+
+  function claimRewards() external onlyMultiSigOrGovernance {
+    ILiquidityMining(rewardPool()).claim();
+    uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+    IERC20(rewardToken()).safeTransfer(msg.sender, remainingRewardBalance);
+  }
+
+  /**
+  * Can completely disable claiming UNI rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    _setSell(s);
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    _setSellFloor(floor);
+  }
+
+  // masterchef rewards pool ID
+  function _setPoolId(uint256 _value) internal {
+    setUint256(_POOLID_SLOT, _value);
+  }
+
+  function poolId() public view returns (uint256) {
+    return getUint256(_POOLID_SLOT);
+  }
+
+  function setUseUni(bool _value) public onlyGovernance {
+    setBoolean(_USE_UNI_SLOT, _value);
+  }
+
+  function useUni() public view returns (bool) {
+    return getBoolean(_USE_UNI_SLOT);
+  }
+
+  function isLpAsset() public view returns (bool) {
+    return getBoolean(_IS_LP_ASSET_SLOT);
+  }
+
+  function setMultiSig(address _address) public onlyGovernance {
+    setAddress(_MULTISIG_SLOT, _address);
+  }
+
+  function multiSig() public view returns (address) {
+    return getAddress(_MULTISIG_SLOT);
+  }
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+    // reset the liquidation paths
+    // they need to be re-set manually
+    if (isLpAsset()) {
+      uniswapRoutes[IUniswapV2Pair(underlying()).token0()] = new address[](0);
+      uniswapRoutes[IUniswapV2Pair(underlying()).token1()] = new address[](0);
+    } else {
+      uniswapRoutes[underlying()] = new address[](0);
+    }
+    _setPausedInvesting(true);
+    setMultiSig(address(0xF49440C1F012d041802b25A73e5B0B9166a75c02));
+  }
+}

--- a/contracts/strategies/complifi/ComplifiStrategyClaimMainnet_COMFI_WETH.sol
+++ b/contracts/strategies/complifi/ComplifiStrategyClaimMainnet_COMFI_WETH.sol
@@ -1,0 +1,31 @@
+pragma solidity 0.5.16;
+
+import "./ComplifiStrategyClaim.sol";
+
+contract ComplifiStrategyClaimMainnet_COMFI_WETH is ComplifiStrategyClaim {
+
+  address public comfi_weth_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xe9C966bc01b4f14c0433800eFbffef4F81540A97);
+    address comfi = address(0x752Efadc0a7E05ad1BCCcDA22c141D01a75EF1e4);
+    address weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    ComplifiStrategyClaim.initializeStrategy(
+      _storage,
+      underlying,
+      _vault,
+      address(0x8a5827Ad1f28d3f397B748CE89895e437b8ef90D), // master chef contract
+      comfi,
+      12,  // Pool id
+      true, // is LP asset
+      true // true = use Uniswap for liquidating
+    );
+    // comfi is token0, weth is token1
+    uniswapRoutes[weth] = [comfi, weth];
+  }
+}

--- a/test/complifi/comfi-weth-claim.js
+++ b/test/complifi/comfi-weth-claim.js
@@ -1,0 +1,96 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const { send } = require("@openzeppelin/test-helpers");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+//const Strategy = artifacts.require("");
+const Strategy = artifacts.require("ComplifiStrategyClaimMainnet_COMFI_WETH");
+
+//This test was developed at blockNumber 13138170
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Complifi: COMFI:WETH Vesting claim", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let treasury = "0x0FB21490A878AA2Af08117C96F897095797bD91C";
+  let reservoir = "0x22e1fe5bBB98a0eDA715B56a7bf04ed462BcA8d2";
+  let comfi = "0x752Efadc0a7E05ad1BCCcDA22c141D01a75EF1e4";
+  let comfiToken;
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xe9C966bc01b4f14c0433800eFbffef4F81540A97");
+    comfiToken = await IERC20.at(comfi);
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+
+    treasuryBalance = await comfiToken.balanceOf(treasury);
+    await comfiToken.transfer(reservoir, treasuryBalance, { from: treasury });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, treasury, msig]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": "0xB89777534acCcc9aE7cbA0e72163f9F214189263",
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "upgradeStrategy": true,
+      "underlying": underlying,
+      "governance": governance,
+    });
+
+    await strategy.finalizeUpgrade({from:governance});
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Rewards should be claimed", async function() {
+      // progress blocks to after "unlockBlock" at 13150000
+      await Utils.advanceNBlock(12000);
+      console.log("Strategy address:", strategy.address);
+
+      let governanceBalanceBefore = new BigNumber(await comfiToken.balanceOf(governance));
+      console.log("Governance COMFI balance before:", governanceBalanceBefore.toFixed());
+
+      await strategy.claimRewards({from:governance});
+
+      let governanceBalanceAfter = new BigNumber(await comfiToken.balanceOf(governance));
+      console.log("Governance COMFI balance after:", governanceBalanceAfter.toFixed());
+
+      Utils.assertBNGt(governanceBalanceAfter, governanceBalanceBefore);
+
+      console.log("MSig address:", await strategy.multiSig());
+    });
+  });
+});

--- a/test/utilities/hh-utils.js
+++ b/test/utilities/hh-utils.js
@@ -191,6 +191,7 @@ async function setupCoreProtocol(config) {
     await Utils.waitHours(13);
     await strategyAsUpgradable.upgrade({ from: config.governance });
     await vault.setVaultFractionToInvest(100, 100, { from: config.governance });
+    strategy = await config.strategyArtifact.at(await vault.strategy());
     console.log("Strategy upgrade completed.");
   } else {
     await controller.addVaultAndStrategy(


### PR DESCRIPTION
Added a `claimRewards` function to the strategy that allows either governance or the msig to claim the vested rewards. Calling `finalizeUpgrade` sets investing to paused and initializes the msig address.

Wrote a test to test the strategy upgrade and claim transaction. All seems to work fine.