### PR TITLE
feat(convex): add strategy for fixed forex ibEUR

### DIFF
--- a/contracts/strategies/convex/ConvexStrategyEURTMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyEURTMainnet.sol
@@ -29,7 +29,8 @@ contract ConvexStrategyEURTMainnet is ConvexStrategyUL {
       0, //depositArrayPosition
       underlying,
       2, //nTokens
-      false //metaPool
+      false, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/ConvexStrategyIbEURMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyIbEURMainnet.sol
@@ -28,7 +28,8 @@ contract ConvexStrategyIbEURMainnet is ConvexStrategyUL {
       0, //depositArrayPosition
       underlying,
       2, //nTokens
-      false //metaPool
+      false, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/ConvexStrategyIbEURMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyIbEURMainnet.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL.sol";
+
+contract ConvexStrategyIbEURMainnet is ConvexStrategyUL {
+
+  address public ibeur_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x19b080FE1ffA0553469D20Ca36219F17Fcf03859);
+    address rewardPool = address(0xCd0559ADb6fAa2fc83aB21Cf4497c3b9b45bB29f);
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address ibeur = address(0x96E61422b6A9bA0e068B6c5ADd4fFaBC6a4aae27);
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, //rewardPool
+      45,  // Pool id
+      ibeur,
+      0, //depositArrayPosition
+      underlying,
+      2, //nTokens
+      false //metaPool
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][ibeur] = [weth, ibeur];
+    storedLiquidationDexes[weth][ibeur] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyMIMMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyMIMMainnet.sol
@@ -30,7 +30,8 @@ contract ConvexStrategyMIMMainnet is ConvexStrategyUL {
       1, //depositArrayPosition
       metaCurveDeposit,
       4, //nTokens
-      true //metaPool
+      true, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx, spell];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/ConvexStrategyOBTCMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyOBTCMainnet.sol
@@ -31,7 +31,8 @@ contract ConvexStrategyOBTCMainnet is ConvexStrategyUL {
       2, //depositArrayPosition
       obtcCurveDeposit,
       4, //nTokens
-      false //metaPool
+      false, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx, bor];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/ConvexStrategyTUSDMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyTUSDMainnet.sol
@@ -29,7 +29,8 @@ contract ConvexStrategyTUSDMainnet is ConvexStrategyUL {
       1, //depositArrayPosition
       metaCurveDeposit,
       4, //nTokens
-      true //metaPool
+      true, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/ConvexStrategycvxCRVMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategycvxCRVMainnet.sol
@@ -27,7 +27,8 @@ contract ConvexStrategycvxCRVMainnet is ConvexStrategyUL {
       0, //depositArrayPosition
       underlying,
       2, //nTokens
-      false //metaPool
+      false, //metaPool
+      1000 // hodlRatio 10%
     );
     rewardTokens = [crv, cvx];
     storedLiquidationPaths[crv][weth] = [crv, weth];

--- a/contracts/strategies/convex/base/ConvexStrategyUL.sol
+++ b/contracts/strategies/convex/base/ConvexStrategyUL.sol
@@ -82,7 +82,7 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
       psNum,  // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
-      1e15, // sell floor
+      0, // sell floor
       12 hours, // implementation change delay
       address(0x7882172921E99d590E097cD600554339fBDBc480) //UL Registry
     );

--- a/contracts/strategies/convex/base/ConvexStrategyUL.sol
+++ b/contracts/strategies/convex/base/ConvexStrategyUL.sol
@@ -65,16 +65,24 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
     bool _metaPool
   ) public initializer {
 
+    // calculate profit sharing fee depending on hodlRatio
+    uint256 psNum = 300;
+    if (hodlRatio() >= 3000) {
+      psNum = 0;
+    } else if (hodlRatio() > 0){
+      psNum = psNum.sub(hodlRatio().div(10)).mul(hodlRatioBase).div(hodlRatioBase.sub(hodlRatio()));
+    }
+    
     BaseUpgradeableStrategyUL.initialize(
       _storage,
       _underlying,
       _vault,
       _rewardPool,
       weth,
-      300,  // profit sharing numerator
+      psNum,  // profit sharing numerator
       1000, // profit sharing denominator
       true, // sell
-      0, // sell floor
+      1e15, // sell floor
       12 hours, // implementation change delay
       address(0x7882172921E99d590E097cD600554339fBDBc480) //UL Registry
     );
@@ -98,6 +106,13 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
   }
 
   function setHodlRatio(uint256 _value) public onlyGovernance {
+    uint256 psNum = 300;
+    if (_value >= 3000) {
+      psNum = 0;
+    } else if (_value > 0){
+      psNum = psNum.sub(_value.div(10)).mul(hodlRatioBase).div(hodlRatioBase.sub(_value));
+    }
+    _setProfitSharingNumerator(psNum);
     setUint256(_HODL_RATIO_SLOT, _value);
   }
 

--- a/contracts/strategies/convex/base/ConvexStrategyUL.sol
+++ b/contracts/strategies/convex/base/ConvexStrategyUL.sol
@@ -62,15 +62,16 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
     uint256 _depositArrayPosition,
     address _curveDeposit,
     uint256 _nTokens,
-    bool _metaPool
+    bool _metaPool,
+    uint256 _hodlRatio
   ) public initializer {
 
     // calculate profit sharing fee depending on hodlRatio
     uint256 psNum = 300;
-    if (hodlRatio() >= 3000) {
+    if (_hodlRatio >= 3000) {
       psNum = 0;
-    } else if (hodlRatio() > 0){
-      psNum = psNum.sub(hodlRatio().div(10)).mul(hodlRatioBase).div(hodlRatioBase.sub(hodlRatio()));
+    } else if (_hodlRatio > 0){
+      psNum = psNum.sub(_hodlRatio.div(10)).mul(hodlRatioBase).div(hodlRatioBase.sub(_hodlRatio));
     }
     
     BaseUpgradeableStrategyUL.initialize(

--- a/contracts/strategies/convex/base/ConvexStrategyUL.sol
+++ b/contracts/strategies/convex/base/ConvexStrategyUL.sol
@@ -75,7 +75,7 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
       // e.g. with default values: (300 - 1000 / 10) * 10000 / (10000 - 1000)
       // = (300 - 100) * 10000 / 9000 = 222
       profitSharingNumerator = profitSharingNumerator.sub(_hodlRatio.div(10)) // subtract hodl ratio from profit sharing numerator
-                                    .mul(holdRatioBase) // multiply with hodlRatioBase
+                                    .mul(hodlRatioBase) // multiply with hodlRatioBase
                                     .div(hodlRatioBase.sub(_hodlRatio)); // divide by hodlRatioBase minus hodlRatio
     }
     
@@ -119,9 +119,9 @@ contract ConvexStrategyUL is IStrategy, BaseUpgradeableStrategyUL {
       // (profitSharingNumerator - hodlRatio/10) * hodlRatioBase / (hodlRatioBase - hodlRatio)
       // e.g. with default values: (300 - 1000 / 10) * 10000 / (10000 - 1000)
       // = (300 - 100) * 10000 / 9000 = 222
-      profitSharingNumerator = profitSharingNumerator.sub(_hodlRatio.div(10)) // subtract hodl ratio from profit sharing numerator
-                                    .mul(holdRatioBase) // multiply with hodlRatioBase
-                                    .div(hodlRatioBase.sub(_hodlRatio)); // divide by hodlRatioBase minus hodlRatio
+      profitSharingNumerator = profitSharingNumerator.sub(_value.div(10)) // subtract hodl ratio from profit sharing numerator
+                                    .mul(hodlRatioBase) // multiply with hodlRatioBase
+                                    .div(hodlRatioBase.sub(_value)); // divide by hodlRatioBase minus hodlRatio
     }
     _setProfitSharingNumerator(profitSharingNumerator);
     setUint256(_HODL_RATIO_SLOT, _value);

--- a/test/convex/cvxcrv.js
+++ b/test/convex/cvxcrv.js
@@ -2,8 +2,6 @@
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
 
-const addresses = require("../test-config.js");
-const { send } = require("@openzeppelin/test-helpers");
 const BigNumber = require("bignumber.js");
 const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
 const IBooster = artifacts.require("IBooster");

--- a/test/convex/eurt.js
+++ b/test/convex/eurt.js
@@ -2,8 +2,6 @@
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
 
-const addresses = require("../test-config.js");
-const { send } = require("@openzeppelin/test-helpers");
 const BigNumber = require("bignumber.js");
 const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
 const IBooster = artifacts.require("IBooster");

--- a/test/convex/ibeur.js
+++ b/test/convex/ibeur.js
@@ -1,0 +1,137 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+const IBooster = artifacts.require("IBooster");
+
+const Strategy = artifacts.require("ConvexStrategyIbEURMainnet");
+
+//This test was developed at blockNumber 13295726
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex IbEUR", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x3Ee505bA316879d246a8fD2b3d7eE63b51B44FAB";
+  let crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+  let cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+  let ibeur = "0x96E61422b6A9bA0e068B6c5ADd4fFaBC6a4aae27";
+  let weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  let hodlVault = "0xF49440C1F012d041802b25A73e5B0B9166a75c02";
+  let booster;
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0x19b080FE1ffA0553469D20Ca36219F17Fcf03859");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 1e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+      "liquidation": [{"sushi": [cvx, weth]},
+                      {"sushi": [crv, weth]},
+                      {"sushi": [weth, ibeur]}],
+
+    });
+
+    await strategy.setSellFloor(0, {from:governance});
+
+    booster = await IBooster.at("0xF403C135812408BFbE8713b5A23a04b3D48AAE31");
+
+    // whale send underlying to farmers
+    await setupBalance();
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+      let cvxToken = await IERC20.at("0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B");
+      let hodlOldBalance = new BigNumber(await cvxToken.balanceOf(hodlVault));
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+
+        await booster.earmarkRewards(await strategy.poolId());
+
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/272))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/272))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      await vault.withdraw(fTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      let hodlNewBalance = new BigNumber(await cvxToken.balanceOf(hodlVault));
+      console.log("CVX before", hodlOldBalance.toFixed());
+      console.log("CVX after ", hodlNewBalance.toFixed());
+      Utils.assertBNGt(hodlNewBalance, hodlOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});

--- a/test/convex/mim.js
+++ b/test/convex/mim.js
@@ -2,8 +2,6 @@
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
 
-const addresses = require("../test-config.js");
-const { send } = require("@openzeppelin/test-helpers");
 const BigNumber = require("bignumber.js");
 const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
 const IBooster = artifacts.require("IBooster");

--- a/test/convex/obtc.js
+++ b/test/convex/obtc.js
@@ -2,8 +2,6 @@
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
 
-const addresses = require("../test-config.js");
-const { send } = require("@openzeppelin/test-helpers");
 const BigNumber = require("bignumber.js");
 const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
 const IBooster = artifacts.require("IBooster");

--- a/test/convex/tusd.js
+++ b/test/convex/tusd.js
@@ -2,8 +2,6 @@
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
 
-const addresses = require("../test-config.js");
-const { send } = require("@openzeppelin/test-helpers");
 const BigNumber = require("bignumber.js");
 const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
 const IBooster = artifacts.require("IBooster");


### PR DESCRIPTION
Adds Convex strategy for fixed forex EUR (ibEUR).

Current sushiswap liquidation pool size: https://analytics.sushi.com/pairs/0xa2d81bedf22201a77044cdf3ab4d9dc1ffbc391b
![image](https://user-images.githubusercontent.com/6112929/134780650-d91ed7d4-78d7-400a-832b-d84ba632bd42.png)

Test output on block `13295726` (`npx hardhat test ./test/convex/ibeur.js`):

```
  Mainnet Convex IbEUR
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x3Ee505bA316879d246a8fD2b3d7eE63b51B44FAB
Fetching Underlying at:  0x19b080FE1ffA0553469D20Ca36219F17Fcf03859
New Vault Deployed:  0x7068C04Abda4990691A1b7561A140C957F82bdB8
Strategy Deployed:  0x922D6956C99E12DFeB3224DEA977D0939758A1Fe
Strategy and vault added to Controller.
    Happy path
loop  0
old shareprice:  1000000000000000000
new shareprice:  1000000000000000000
growth:  1
instant APR: 0 %
instant APY: 0 %
loop  1
old shareprice:  1000000000000000000
new shareprice:  1000282675235823264
growth:  1.0002826752358231
instant APR: 28.063997412522212 %
instant APY: 32.38340908469992 %
loop  2
old shareprice:  1000282675235823264
new shareprice:  1000570350827542497
growth:  1.000287594295934
instant APR: 28.55236170032217 %
instant APY: 33.031000143322366 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  3
old shareprice:  1000570350827542497
new shareprice:  1000862701797814779
growth:  1.000292184322702
instant APR: 29.00805955784953 %
instant APY: 33.63812311842196 %
loop  4
old shareprice:  1000862701797814779
new shareprice:  1001159445066737939
growth:  1.0002964874886338
instant APR: 29.435277871559347 %
instant APY: 34.20981227533106 %
loop  5
old shareprice:  1001159445066737939
new shareprice:  1001460308519249895
growth:  1.0003005150218525
instant APR: 29.83513136951277 %
instant APY: 34.74709212509328 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  6
old shareprice:  1001460308519249895
new shareprice:  1001761238276570705
growth:  1.0003004909478297
instant APR: 29.83274130053164 %
instant APY: 34.743874245290904 %
loop  7
old shareprice:  1001761238276570705
new shareprice:  1002062242177739605
growth:  1.0003004746936373
instant APR: 29.83112758430655 %
instant APY: 34.74170165474675 %
loop  8
old shareprice:  1002062242177739605
new shareprice:  1002363304549738664
growth:  1.0003004427862132
instant APR: 29.827959815248228 %
instant APY: 34.737436901726014 %
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.
loop  9
old shareprice:  1002363304549738664
new shareprice:  1002664441071243575
growth:  1.0003004265221382
instant APR: 29.82634511788465 %
instant APY: 34.73526309383254 %
CVX before 245540181400820555297
CVX after  246329453767278319972
earned!
Overall APR: 29.442834826658164 %
Overall APY: 34.21994665961985 %
      ✓ Farmer should earn money (51380ms)

  1 passing (1m)
```