### PR TITLE
feat(looks): add single asset staking looks strategy

### DIFF
--- a/contracts/strategies/looksrare/LooksRareStakingStrategy.sol
+++ b/contracts/strategies/looksrare/LooksRareStakingStrategy.sol
@@ -1,0 +1,247 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../base/interface/uniswap/IUniswapV2Router02.sol";
+import "../../base/interface/uniswap/IUniswapV2Pair.sol";
+import "../../base/interface/IStrategy.sol";
+import "../../base/upgradability/BaseUpgradeableStrategyUL.sol";
+import "./interface/IFeeSharingSystem.sol";
+
+import "hardhat/console.sol";
+
+contract LooksRareStakingStrategy is IStrategy, BaseUpgradeableStrategyUL {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+  address public constant uniswapRouterV2 = address(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
+
+  constructor() public BaseUpgradeableStrategyUL() {
+  }
+
+  function initializeBaseStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    address _rewardToken
+  ) public initializer {
+
+    BaseUpgradeableStrategyUL.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _rewardPool,
+      _rewardToken,
+      300,  // profit sharing numerator
+      1000, // profit sharing denominator
+      true, // sell
+      0, // sell floor
+      12 hours, // implementation change delay
+      address(0x7882172921E99d590E097cD600554339fBDBc480) //UL Registry
+    );
+
+    address _lpt = IFeeSharingSystem(rewardPool()).rewardToken();
+    require(_lpt == _rewardToken, "Pool Info does not match rewardToken");
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  function rewardPoolBalance() internal view returns (uint256 bal) {
+      (bal,,) = IFeeSharingSystem(rewardPool()).userInfo(address(this));
+  }
+
+  function exitRewardPool() internal {
+      uint256 stakedBalance = rewardPoolBalance();
+      if (stakedBalance != 0) {
+          // bool flag param for claiming reward tokens set to true
+          IFeeSharingSystem(rewardPool()).withdrawAll(true);
+      }
+  }
+
+  function emergencyExitRewardPool() internal {
+    uint256 stakedBalance = rewardPoolBalance();
+    if (stakedBalance != 0) {
+        // bool flag param for claiming reward tokens set to false
+        IFeeSharingSystem(rewardPool()).withdrawAll(false);
+    }
+  }
+
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying());
+  }
+
+  function enterRewardPool() internal {
+    uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+    IERC20(underlying()).safeApprove(rewardPool(), 0);
+    IERC20(underlying()).safeApprove(rewardPool(), entireBalance);
+
+    // bool flag param for claiming reward tokens set to false
+    IFeeSharingSystem(rewardPool()).deposit(entireBalance, false);
+  }
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  function _liquidateReward() internal {
+    uint256 rewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+    if (!sell() || rewardBalance < sellFloor()) {
+      // Profits can be disabled for possible simplified and rapid exit
+      emit ProfitsNotCollected(sell(), rewardBalance < sellFloor());
+      return;
+    }
+
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(rewardToken()).balanceOf(address(this));
+
+    if (remainingRewardBalance <= 0) {
+      return;
+    }
+
+    IERC20(rewardToken()).safeApprove(universalLiquidator(), 0);
+    IERC20(rewardToken()).safeApprove(universalLiquidator(), remainingRewardBalance);
+
+    // we can accept 1 as minimum because this is called only by a trusted role
+    ILiquidator(universalLiquidator()).swapTokenOnMultipleDEXes(
+      remainingRewardBalance,
+      1,
+      address(this), // target
+      storedLiquidationDexes[rewardToken()][underlying()],
+      storedLiquidationPaths[rewardToken()][underlying()]
+    );
+  }
+
+  /*
+  *   Stakes everything the strategy holds into the reward pool
+  */
+  function investAllUnderlying() internal onlyNotPausedInvesting {
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      enterRewardPool();
+    }
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    if (address(rewardPool()) != address(0)) {
+      exitRewardPool();
+    }
+    _liquidateReward();
+    IERC20(underlying()).safeTransfer(vault(), IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws the amount for the asset to the vault
+  */
+  function withdrawToVault(uint256 amount) public restricted {
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    uint256 entireBalance = IERC20(underlying()).balanceOf(address(this));
+
+    if(amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdrawLOOKS = amount.sub(entireBalance);
+
+      // convert amount of underlying to withdraw to shares price
+      uint256 oneShareInLOOKS = IFeeSharingSystem(rewardPool()).calculateSharePriceInLOOKS();
+      uint256 needToWithdrawShares = needToWithdrawLOOKS.div(oneShareInLOOKS);
+
+      uint256 sharesToWithdraw = Math.min(rewardPoolBalance(), needToWithdrawShares);
+
+      // bool flag param for claiming reward tokens set to false
+      IFeeSharingSystem(rewardPool()).withdraw(sharesToWithdraw, false);
+    }
+
+    uint256 underlyingBalance = IERC20(underlying()).balanceOf(address(this));
+
+    // recalculate to improve accuracy
+    uint256 underlyingAmountToWithdraw = Math.min(amount, underlyingBalance);
+
+    IERC20(underlying()).safeTransfer(vault(), underlyingAmountToWithdraw);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    if (rewardPool() == address(0)) {
+      return IERC20(underlying()).balanceOf(address(this));
+    }
+
+    // using the calculateSharePriceInLOOKS instead of the calculateSharesValueInLOOKS is more exact
+    uint256 oneShareInLOOKS = IFeeSharingSystem(rewardPool()).calculateSharePriceInLOOKS();
+    uint256 balanceInLOOKS = rewardPoolBalance().mul(oneShareInLOOKS);
+
+    // Adding the amount locked in the reward pool and the amount that is somehow in this contract
+    // both are in the units of "underlying"
+    // The second part is needed because there is the emergency exit mechanism
+    // which would break the assumption that all the funds are always inside of the reward pool
+    return balanceInLOOKS.add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(token), "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    uint256 pendingRewards = IFeeSharingSystem(rewardPool()).calculatePendingRewards(address(this));
+    console.log("doing hardwork, pending rewards in WETH:", pendingRewards);
+    if (pendingRewards > 0) {
+      IFeeSharingSystem(rewardPool()).harvest();
+    }
+    _liquidateReward();
+    investAllUnderlying();
+  }
+
+  /**
+  * Can completely disable claiming UNI rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    _setSell(s);
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    _setSellFloor(floor);
+  }
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+  }
+}

--- a/contracts/strategies/looksrare/LooksRareStakingStrategyMainnet_LOOKS.sol
+++ b/contracts/strategies/looksrare/LooksRareStakingStrategyMainnet_LOOKS.sol
@@ -1,0 +1,28 @@
+pragma solidity 0.5.16;
+
+import "./LooksRareStakingStrategy.sol";
+
+contract LooksRareStakingStrategyMainnet_LOOKS is LooksRareStakingStrategy {
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address looks = address(0xf4d2888d29D722226FafA5d9B24F9164c092421E); // underlying = LOOKS
+    address rewardPool = address(0xBcD7254A1D759EFA08eC7c3291B2E85c5dCC12ce);
+    address weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    bytes32 uniV2Dex = bytes32(0xde2d1a51640f78257713031680d1f306297d957426e912ab21317b9cc9495a41);
+    
+    LooksRareStakingStrategy.initializeBaseStrategy(
+      _storage,
+      looks, // underlying
+      _vault,
+      rewardPool,
+      weth // rewardToken
+    );
+    storedLiquidationPaths[weth][looks] = [weth, looks];
+    storedLiquidationDexes[weth][looks] = [uniV2Dex];
+  }
+}

--- a/contracts/strategies/looksrare/interface/IFeeSharingSetter.sol
+++ b/contracts/strategies/looksrare/interface/IFeeSharingSetter.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.5.16;
+
+/**
+ * Contract used to simulate rewards distrubation at LOOKS smart contracts in our tests
+ */
+interface IFeeSharingSetter {
+    // only executable by operator role
+    function updateRewards() external;
+
+    function rewardDurationInBlocks() external view returns(uint256);
+
+    function lastRewardDistributionBlock() external view returns(uint256);
+}

--- a/contracts/strategies/looksrare/interface/IFeeSharingSystem.sol
+++ b/contracts/strategies/looksrare/interface/IFeeSharingSystem.sol
@@ -1,0 +1,33 @@
+pragma solidity 0.5.16;
+
+/**
+ * Contract used for single asset LOOKS staking which rewards autocompounded LOOKS and 
+ * not autocompounded WETH as part of the fee sharing model
+ */
+interface IFeeSharingSystem {
+    // returns shares uint256, userRewardPerTokenPaid uint256, rewards uint256
+    function userInfo(address account) external view returns (uint256, uint256, uint256);
+
+    function rewardToken() external view returns (address);
+
+    // Calculate pending rewards (WETH) for a user
+    function calculatePendingRewards(address user) external view returns (uint256);
+
+    // Harvest reward tokens that are pending
+    function harvest() external;
+
+    // Deposit staked tokens (and collect reward tokens if requested)
+    function deposit(uint256 amount, bool claimRewardToken) external;
+
+    // Withdraw staked tokens (and collect reward tokens if requested)
+    function withdraw(uint256 amount, bool claimRewardToken) external;
+
+    // Withdraw all staked tokens (and collect reward tokens if requested)
+    function withdrawAll(bool claimRewardToken) external;
+    
+    // Calculate price of one share (in LOOKS token) Share price is expressed times 1e18
+    function calculateSharePriceInLOOKS() external view returns(uint256);
+
+    // Calculate value of LOOKS for a user given a number of shares owned
+    function calculateSharesValueInLOOKS(address user) external view returns(uint256);
+}

--- a/contracts/strategies/looksrare/interface/IOperatorControllerForRewards.sol
+++ b/contracts/strategies/looksrare/interface/IOperatorControllerForRewards.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.5.16;
+
+/**
+ * Contract used to simulate rewards distrubation at LOOKS smart contracts in our tests
+ */
+interface IOperatorControllerForRewards {
+    // only executable by owner
+    function releaseTokensAndUpdateRewards() external;
+}

--- a/test/looksrare/looks.js
+++ b/test/looksrare/looks.js
@@ -1,6 +1,7 @@
 // Utilities
 const Utils = require("../utilities/Utils.js");
 const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+const { time } = require("@openzeppelin/test-helpers");
 
 const addresses = require("../test-config.js");
 const BigNumber = require("bignumber.js");
@@ -8,8 +9,12 @@ const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol
 
 const Strategy = artifacts.require("LooksRareStakingStrategyMainnet_LOOKS");
 const IFeeRewardForwarder = artifacts.require("IFeeRewardForwarderV6");
+const IOperatorControllerForRewards = artifacts.require("IOperatorControllerForRewards");
+const IFeeSharingSetter = artifacts.require("IFeeSharingSetter");
 
-//This test was developed at blockNumber 14037259
+// This test was developed at blockNumber 14033537
+// for this test we simulate repleneshing rewards so the block number depends on
+// a good timing of when the repleneshing last happened to get realistic results
 
 // Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
 describe("Mainnet LooksRare Staking LOOKS", function() {
@@ -19,10 +24,17 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
   let underlying;
 
   // external setup
-  let underlyingWhale = "0x3D5202A0564De9B05eCd07C955BcCA964585ea03";
+  let underlyingWhale = "0x52329Bf439AF2381eC3a22CF702d9f82562F820f";
   let looks = "0xf4d2888d29D722226FafA5d9B24F9164c092421E";
   let weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
   let feeForwarderAddr = "0x153C544f72329c1ba521DDf5086cf2fA98C86676";
+
+  // used to update rewards simulated for the distribution from LOOKS smart contracts
+  let operatorControllerForRewards;
+  let operatorControllerForRewardsAddress = "0xb6c40EB22dBdC87FdDf4B70d460934a44b7EbE01";
+  let rewardsControllerOwner = "0xAa27e4FCCcBF24B1f745cf5b2ECee018E91a5e5e";
+  let feeSharingSetter;
+  let feeSharingSetterAddr = "0x5924A28caAF1cc016617874a2f0C3710d881f3c1";
 
   let bancorDex = "0x4bf11b89310db45ea1467e48e832606a6ec7b8735c470fff7cf328e182a7c37e";
 
@@ -49,6 +61,7 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
     // Give whale some ether to make sure the following actions are good
     await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 10e18});
     await web3.eth.sendTransaction({ from: etherGiver, to: governance, value: 10e18});
+    await web3.eth.sendTransaction({ from: etherGiver, to: rewardsControllerOwner, value: 10e18});
 
     farmerBalance = await underlying.balanceOf(underlyingWhale);
     await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
@@ -61,7 +74,7 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
     farmer1 = accounts[1];
 
     // impersonate accounts
-    await impersonates([governance, underlyingWhale]);
+    await impersonates([governance, underlyingWhale, rewardsControllerOwner]);
 
     await setupExternalContracts();
     // whale send underlying to farmers
@@ -76,6 +89,9 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
       "liquidation": [{"uni": [weth, looks]}],
     });
 
+    operatorControllerForRewards = await IOperatorControllerForRewards.at(operatorControllerForRewardsAddress);
+    feeSharingSetter = await IFeeSharingSetter.at(feeSharingSetterAddr);
+
     let feeForwarder = await IFeeRewardForwarder.at(feeForwarderAddr);
     let path = [weth, addresses.FARM];
     let dexes = [bancorDex];
@@ -88,18 +104,45 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
       await depositVault(farmer1, underlying, vault, farmerBalance);
       let fTokenBalance = await vault.balanceOf(farmer1);
 
+      let wethWhale = "0xE78388b4CE79068e89Bf8aA7f218eF6b9AB0e9d0";
+      await impersonates([governance, underlyingWhale, rewardsControllerOwner, wethWhale]);
+      let wethERC20 = await IERC20.at(weth);
+      let initalFeeSharingSetterBalance = await wethERC20.balanceOf(feeSharingSetterAddr);
+      console.log("initalFeeSharingSetterBalance (used throughout test as rewards base)")
+      console.log(new BigNumber(initalFeeSharingSetterBalance).toFixed());
+
       // Using half days is to simulate how we doHardwork in the real world
       let hours = 10;
       let blocksPerHour = 2400;
       let oldSharePrice;
       let newSharePrice;
       for (let i = 0; i < hours; i++) {
-        console.log("loop ", i);
+        console.log("\n\n ----------------- loop ", i, " -----------------------");
+
+        // check if we have to simulate updating rewards at LOOKS fee sharing system
+        const rewardDurationInBlocks = await feeSharingSetter.rewardDurationInBlocks();
+        const lastRewardDistributionBlock = await feeSharingSetter.lastRewardDistributionBlock();
+        const block = await time.latestBlock();
+
+        if(block > new BigNumber(rewardDurationInBlocks).plus(lastRewardDistributionBlock)){
+          console.log("\nSimulating updating rewards");
+          const currentFeeSharingSetterBalance = await wethERC20.balanceOf(feeSharingSetterAddr);
+          console.log("currentFeeSharingSetterBalance:", new BigNumber(currentFeeSharingSetterBalance).toFixed())
+          const balanceDifference = new BigNumber(initalFeeSharingSetterBalance).minus(currentFeeSharingSetterBalance);
+          if(balanceDifference > 0){
+            // LOOKS feeSharingSystem calculates rewards based on balance of WETH in the contract
+            // we simulate the contract having the same balance at the beginning of the test
+            console.log("repleneshing feeSetterBalance with WETH: ", new BigNumber(balanceDifference).toFixed());
+            await wethERC20.transfer(feeSharingSetterAddr, balanceDifference, { from: wethWhale });
+          }
+          await operatorControllerForRewards.releaseTokensAndUpdateRewards({from: rewardsControllerOwner});
+        }
+
         oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
         await controller.doHardWork(vault.address, { from: governance });
         newSharePrice = new BigNumber(await vault.getPricePerFullShare());
 
-        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("\nold shareprice: ", oldSharePrice.toFixed());
         console.log("new shareprice: ", newSharePrice.toFixed());
         console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
 
@@ -108,13 +151,16 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
 
         console.log("instant APR:", apr*100, "%");
         console.log("instant APY:", (apy-1)*100, "%");
+        console.log(`Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.`);
 
         await Utils.advanceNBlock(blocksPerHour);
       }
       // withdraw only part to check if the withdrawToVault method works
       await vault.withdraw(new BigNumber(fTokenBalance).div(2), { from: farmer1 });
       let restfTokenBalance = await vault.balanceOf(farmer1);
+      // make sure rest of the balance matches
       Utils.assertBNGte(new BigNumber(fTokenBalance).div(2), restfTokenBalance);
+
       await vault.withdraw(restfTokenBalance, { from: farmer1 });
       let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
       Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
@@ -122,7 +168,7 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
       apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))*365;
       apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))+1)**365;
 
-      console.log("earned!");
+      console.log("\n\n ---------- earned! -----------");
       console.log("Overall APR:", apr*100, "%");
       console.log("Overall APY:", (apy-1)*100, "%");
 

--- a/test/looksrare/looks.js
+++ b/test/looksrare/looks.js
@@ -156,10 +156,11 @@ describe("Mainnet LooksRare Staking LOOKS", function() {
         await Utils.advanceNBlock(blocksPerHour);
       }
       // withdraw only part to check if the withdrawToVault method works
-      await vault.withdraw(new BigNumber(fTokenBalance).div(2), { from: farmer1 });
+      const halfBalance = new BigNumber(fTokenBalance).div(2);
+      await vault.withdraw(halfBalance, { from: farmer1 });
       let restfTokenBalance = await vault.balanceOf(farmer1);
       // make sure rest of the balance matches
-      Utils.assertBNGte(new BigNumber(fTokenBalance).div(2), restfTokenBalance);
+      Utils.assertBNGte(halfBalance, restfTokenBalance);
 
       await vault.withdraw(restfTokenBalance, { from: farmer1 });
       let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));

--- a/test/looksrare/looks.js
+++ b/test/looksrare/looks.js
@@ -1,0 +1,132 @@
+// Utilities
+const Utils = require("../utilities/Utils.js");
+const { impersonates, setupCoreProtocol, depositVault } = require("../utilities/hh-utils.js");
+
+const addresses = require("../test-config.js");
+const BigNumber = require("bignumber.js");
+const IERC20 = artifacts.require("@openzeppelin/contracts/token/ERC20/IERC20.sol:IERC20");
+
+const Strategy = artifacts.require("LooksRareStakingStrategyMainnet_LOOKS");
+const IFeeRewardForwarder = artifacts.require("IFeeRewardForwarderV6");
+
+//This test was developed at blockNumber 14037259
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet LooksRare Staking LOOKS", function() {
+  let accounts;
+
+  // external contracts
+  let underlying;
+
+  // external setup
+  let underlyingWhale = "0x3D5202A0564De9B05eCd07C955BcCA964585ea03";
+  let looks = "0xf4d2888d29D722226FafA5d9B24F9164c092421E";
+  let weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+  let feeForwarderAddr = "0x153C544f72329c1ba521DDf5086cf2fA98C86676";
+
+  let bancorDex = "0x4bf11b89310db45ea1467e48e832606a6ec7b8735c470fff7cf328e182a7c37e";
+
+  // parties in the protocol
+  let governance;
+  let farmer1;
+
+  // numbers used in tests
+  let farmerBalance;
+
+  // Core protocol contracts
+  let controller;
+  let vault;
+  let strategy;
+  let feeForwarder;
+
+  async function setupExternalContracts() {
+    underlying = await IERC20.at("0xf4d2888d29D722226FafA5d9B24F9164c092421E");
+    console.log("Fetching Underlying at: ", underlying.address);
+  }
+
+  async function setupBalance(){
+    let etherGiver = accounts[9];
+    // Give whale some ether to make sure the following actions are good
+    await web3.eth.sendTransaction({ from: etherGiver, to: underlyingWhale, value: 10e18});
+    await web3.eth.sendTransaction({ from: etherGiver, to: governance, value: 10e18});
+
+    farmerBalance = await underlying.balanceOf(underlyingWhale);
+    await underlying.transfer(farmer1, farmerBalance, { from: underlyingWhale });
+  }
+
+  before(async function() {
+    governance = "0xf00dD244228F51547f0563e60bCa65a30FBF5f7f";
+    accounts = await web3.eth.getAccounts();
+
+    farmer1 = accounts[1];
+
+    // impersonate accounts
+    await impersonates([governance, underlyingWhale]);
+
+    await setupExternalContracts();
+    // whale send underlying to farmers
+    await setupBalance();
+
+    [controller, vault, strategy] = await setupCoreProtocol({
+      "existingVaultAddress": null,
+      "strategyArtifact": Strategy,
+      "strategyArtifactIsUpgradable": true,
+      "underlying": underlying,
+      "governance": governance,
+      "liquidation": [{"uni": [weth, looks]}],
+    });
+
+    let feeForwarder = await IFeeRewardForwarder.at(feeForwarderAddr);
+    let path = [weth, addresses.FARM];
+    let dexes = [bancorDex];
+    await feeForwarder.configureLiquidation(path, dexes, {from: governance});
+  });
+
+  describe("Happy path", function() {
+    it("Farmer should earn money", async function() {
+      let farmerOldBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      await depositVault(farmer1, underlying, vault, farmerBalance);
+      let fTokenBalance = await vault.balanceOf(farmer1);
+
+      // Using half days is to simulate how we doHardwork in the real world
+      let hours = 10;
+      let blocksPerHour = 2400;
+      let oldSharePrice;
+      let newSharePrice;
+      for (let i = 0; i < hours; i++) {
+        console.log("loop ", i);
+        oldSharePrice = new BigNumber(await vault.getPricePerFullShare());
+        await controller.doHardWork(vault.address, { from: governance });
+        newSharePrice = new BigNumber(await vault.getPricePerFullShare());
+
+        console.log("old shareprice: ", oldSharePrice.toFixed());
+        console.log("new shareprice: ", newSharePrice.toFixed());
+        console.log("growth: ", newSharePrice.toFixed() / oldSharePrice.toFixed());
+
+        apr = (newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/272))*365;
+        apy = ((newSharePrice.toFixed()/oldSharePrice.toFixed()-1)*(24/(blocksPerHour/272))+1)**365;
+
+        console.log("instant APR:", apr*100, "%");
+        console.log("instant APY:", (apy-1)*100, "%");
+
+        await Utils.advanceNBlock(blocksPerHour);
+      }
+      // withdraw only part to check if the withdrawToVault method works
+      await vault.withdraw(new BigNumber(fTokenBalance).div(2), { from: farmer1 });
+      let restfTokenBalance = await vault.balanceOf(farmer1);
+      Utils.assertBNGte(new BigNumber(fTokenBalance).div(2), restfTokenBalance);
+      await vault.withdraw(restfTokenBalance, { from: farmer1 });
+      let farmerNewBalance = new BigNumber(await underlying.balanceOf(farmer1));
+      Utils.assertBNGt(farmerNewBalance, farmerOldBalance);
+
+      apr = (farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))*365;
+      apy = ((farmerNewBalance.toFixed()/farmerOldBalance.toFixed()-1)*(24/(blocksPerHour*hours/272))+1)**365;
+
+      console.log("earned!");
+      console.log("Overall APR:", apr*100, "%");
+      console.log("Overall APY:", (apy-1)*100, "%");
+
+      await strategy.withdrawAllToVault({ from: governance }); // making sure can withdraw all for a next switch
+    });
+  });
+});


### PR DESCRIPTION
Implements LOOKS single asset staking strategy.

LOOKS is already autocompounded, this strategy autocompounds the WETH rewards.

Liquidation routes are the same as already in place for the LOOKS-ETH strategy, on UniV2.

The test simulates replenishing rewards at the LOOKS FeeSharingSystem.

Tests results (`npx hardhat test ./test/looksrare/looks.js`) at blockNumber `14033537` (important also for the simulation of rewards in this test): 
```
Mainnet LooksRare Staking LOOKS
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x52329Bf439AF2381eC3a22CF702d9f82562F820f
0xAa27e4FCCcBF24B1f745cf5b2ECee018E91a5e5e
Fetching Underlying at:  0xf4d2888d29D722226FafA5d9B24F9164c092421E
New Vault Deployed:  0x5a2438A95d808A6e0Db8c0B687ab541630489Bc2
Strategy Deployed:  0xE3011A37A904aB90C8881a99BD1F6E21401f1522
Strategy and vault added to Controller.
    Happy path
Impersonating...
0xf00dD244228F51547f0563e60bCa65a30FBF5f7f
0x52329Bf439AF2381eC3a22CF702d9f82562F820f
0xAa27e4FCCcBF24B1f745cf5b2ECee018E91a5e5e
0xE78388b4CE79068e89Bf8aA7f218eF6b9AB0e9d0
initalFeeSharingSetterBalance (used throughout test as rewards base)
5104975955440419800000


 ----------------- loop  0  -----------------------

Simulating updating rewards
currentFeeSharingSetterBalance: 5104975955440419800000

old shareprice:  1000000000000000000
new shareprice:  999999999999999999
growth:  1
instant APR: 0 %
instant APY: 0 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  1  -----------------------

old shareprice:  1003779482755999999
new shareprice:  1007988805615778638
growth:  1.0041934736982485
instant APR: 416.3280687621128 %
instant APY: 6178.498805202206 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  2  -----------------------

old shareprice:  1011784126609933802
new shareprice:  1016010415882271612
growth:  1.0041770661954328
instant APR: 414.69913188256714 %
instant APY: 6078.187163573251 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  3  -----------------------

Simulating updating rewards
currentFeeSharingSetterBalance: 0
repleneshing feeSetterBalance with WETH:  5104975955440419800000

old shareprice:  1019824755203883331
new shareprice:  1019828107732733065
growth:  1.0000032873577862
instant APR: 0.32636888101473355 %
instant APY: 0.3269005802245095 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.


 ----------------- loop  4  -----------------------

old shareprice:  1023639271084956020
new shareprice:  1027877190932389328
growth:  1.0041400520350705
instant APR: 411.0243660417999 %
instant APY: 5857.722306885549 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  5  -----------------------

old shareprice:  1031704128369162612
new shareprice:  1035958906273153667
growth:  1.0041240291542854
instant APR: 409.4336144374591 %
instant APY: 5764.736353612598 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  6  -----------------------

Simulating updating rewards
currentFeeSharingSetterBalance: 0
repleneshing feeSetterBalance with WETH:  5104975955440419800000

old shareprice:  1039804817418351816
new shareprice:  1039808193544133214
growth:  1.0000032468841507
instant APR: 0.3223506584769175 %
instant APY: 0.32286933891048086 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.


 ----------------- loop  7  -----------------------

old shareprice:  1043650902432544647
new shareprice:  1047913927056422305
growth:  1.0040847227879948
instant APR: 405.53127839212027 %
instant APY: 5542.713186179055 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  8  -----------------------

old shareprice:  1051772327982831094
new shareprice:  1056052070544120937
growth:  1.004069076973624
instant APR: 403.97796194139255 %
instant APY: 5456.687778258825 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.


 ----------------- loop  9  -----------------------

Simulating updating rewards
currentFeeSharingSetterBalance: 0
repleneshing feeSetterBalance with WETH:  5104975955440419800000

old shareprice:  1059929389061986540
new shareprice:  1059932788663381964
growth:  1.0000032073847849
instant APR: 0.3184291614424595 %
instant APY: 0.31893529223305794 %
Instant APR / APY might be a bit off in this test depending on the loop, make sure the Overall APR / APY is in line.
@openzeppelin/test-helpers WARN advanceBlockTo: Advancing too many blocks is causing this test to be slow.


 ---------- earned! -----------
Overall APR: 676.0797662894371 %
Overall APY: 81055.00357693664 %
      ✓ Farmer should earn money (44019ms)


  1 passing (53s)
```