### PR TITLE
New Convex strategy suggestions

### DIFF
--- a/contracts/base/interface/curve/ICurveDeposit_3token_meta.sol
+++ b/contracts/base/interface/curve/ICurveDeposit_3token_meta.sol
@@ -1,0 +1,19 @@
+pragma solidity 0.5.16;
+
+interface ICurveDeposit_3token_meta {
+  function add_liquidity(
+    address pool,
+    uint256[3] calldata amounts,
+    uint256 min_mint_amount
+  ) external;
+  function remove_liquidity_imbalance(
+    address pool,
+    uint256[3] calldata amounts,
+    uint256 max_burn_amount
+  ) external;
+  function remove_liquidity(
+    address pool,
+    uint256 _amount,
+    uint256[3] calldata amounts
+  ) external;
+}

--- a/contracts/strategies/convex/ConvexStrategyAlETHMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyAlETHMainnet.sol
@@ -1,0 +1,39 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyAlETHMainnet is ConvexStrategyUL_V2 {
+
+  address public aleth_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e); // Info -> LP Token address
+    address rewardPool = address(0x48Bc302d8295FeA1f8c3e7F57D4dDC9981FEE410); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      49,  // Pool id: Info -> Rewards contract address -> read -> pid
+      weth, // depositToken
+      0, //depositArrayPosition. Find deposit transaction -> input params
+      underlying, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyApeUSD_FRAXBPMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyApeUSD_FRAXBPMainnet.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyApeUSD_FRAXBPMainnet is ConvexStrategyUL_V2 {
+
+  address public ApeUSD_FRAXBP_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x04b727C7e246CA70d496ecF52E6b6280f3c8077D); // Info -> LP Token address
+    address rewardPool = address(0x51e6B84968D56a1E5BC93Ee264e95b1Ea577339c); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address usdc = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address curveDeposit = address(0x08780fb7E580e492c1935bEe4fA5920b94AA95Da); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      103,  // Pool id: Info -> Rewards contract address -> read -> pid
+      usdc, // depositToken
+      2, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      3, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][usdc] = [weth, usdc];
+    storedLiquidationDexes[weth][usdc] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyCRV_ETHMainnetV2.sol
+++ b/contracts/strategies/convex/ConvexStrategyCRV_ETHMainnetV2.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyCRV_ETHMainnetV2 is ConvexStrategyUL_V2 {
+
+  address public crv_eth_v2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xEd4064f376cB8d68F770FB1Ff088a3d0F3FF5c4d); // Info -> LP Token address
+    address rewardPool = address(0x085A2054c51eA5c91dbF7f90d65e728c0f2A270f); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address curveDeposit = address(0x8301AE4fc9c624d1D396cbDAa1ed877821D7C511); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      61,  // Pool id: Info -> Rewards contract address -> read -> pid
+      crv, // depositToken
+      1, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+
+    _setRewardToken(crv);
+
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[cvx][crv] = [cvx, crv];
+    storedLiquidationDexes[cvx][crv] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyCVX_ETHMainnetV2.sol
+++ b/contracts/strategies/convex/ConvexStrategyCVX_ETHMainnetV2.sol
@@ -4,7 +4,7 @@ import "./base/ConvexStrategyUL_V2.sol";
 
 contract ConvexStrategyCVX_ETHMainnetV2 is ConvexStrategyUL_V2 {
 
-  address public crv_eth_v2_unused; // just a differentiator for the bytecode
+  address public cvx_eth_v2_unused; // just a differentiator for the bytecode
 
   constructor() public {}
 

--- a/contracts/strategies/convex/ConvexStrategyCVX_ETHMainnetV2.sol
+++ b/contracts/strategies/convex/ConvexStrategyCVX_ETHMainnetV2.sol
@@ -1,0 +1,41 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyCVX_ETHMainnetV2 is ConvexStrategyUL_V2 {
+
+  address public crv_eth_v2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x3A283D9c08E8b55966afb64C515f5143cf907611); // Info -> LP Token address
+    address rewardPool = address(0xb1Fb0BA0676A1fFA83882c7F4805408bA232C1fA); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address curveDeposit = address(0xB576491F1E6e5E62f1d8F26062Ee822B40B0E0d4); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      64,  // Pool id: Info -> Rewards contract address -> read -> pid
+      cvx, // depositToken
+      1, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+
+    _setRewardToken(cvx);
+
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][cvx] = [crv, cvx];
+    storedLiquidationDexes[crv][cvx] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyCvxFXSMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyCvxFXSMainnet.sol
@@ -1,0 +1,45 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyCvxFXSMainnet is ConvexStrategyUL_V2 {
+
+  address public cvxfxs_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xF3A43307DcAFa93275993862Aae628fCB50dC768); // Info -> LP Token address
+    address rewardPool = address(0xf27AFAD0142393e4b3E5510aBc5fe3743Ad669Cb); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address fxs = address(0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0);
+    address curveDeposit = address(0xd658A338613198204DCa1143Ac3F01A722b5d94A);
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      72,  // Pool id: Info -> Rewards contract address -> read -> pid
+      fxs, // depositToken
+      0, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx, fxs];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[fxs][weth] = [fxs, weth];
+    storedLiquidationDexes[fxs][weth] = [sushiDex];
+    storedLiquidationPaths[weth][fxs] = [weth, fxs];
+    storedLiquidationDexes[weth][fxs] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyDOLA_FRAXBPMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyDOLA_FRAXBPMainnet.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyDOLA_FRAXBPMainnet is ConvexStrategyUL_V2 {
+
+  address public DOLA_FRAXBP_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xE57180685E3348589E9521aa53Af0BCD497E884d); // Info -> LP Token address
+    address rewardPool = address(0x0404d05F3992347d2f0dC3a97bdd147D77C85c1c); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address usdc = address(0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48);
+    address curveDeposit = address(0x08780fb7E580e492c1935bEe4fA5920b94AA95Da); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      115,  // Pool id: Info -> Rewards contract address -> read -> pid
+      usdc, // depositToken
+      2, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      3, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][usdc] = [weth, usdc];
+    storedLiquidationDexes[weth][usdc] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyHBTCMainnetV2.sol
+++ b/contracts/strategies/convex/ConvexStrategyHBTCMainnetV2.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyHBTCMainnetV2 is ConvexStrategyUL_V2 {
+
+  address public hbtc_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xb19059ebb43466C323583928285a49f558E572Fd); // Info -> LP Token address
+    address rewardPool = address(0x618BD6cBA676a46958c63700C04318c84a7b7c0A); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address wbtc = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    address curveDeposit = address(0x4CA9b3063Ec5866A4B82E437059D2C43d1be596F); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      8,  // Pool id: Info -> Rewards contract address -> read -> pid
+      wbtc, // depositToken
+      1, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][wbtc] = [weth, wbtc];
+    storedLiquidationDexes[weth][wbtc] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyPBTCMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyPBTCMainnet.sol
@@ -1,0 +1,48 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyPBTCMainnet is ConvexStrategyUL_V2 {
+
+  address public pbtc_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xC9467E453620f16b57a34a770C6bceBECe002587); // Info -> LP Token address
+    address rewardPool = address(0x589761B61D8d1C8ecc36F3cFE35932670749015a); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address pnt = address(0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD);
+    address wbtc = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    address curveDeposit = address(0x7AbDBAf29929e7F8621B757D2a7c04d78d633834); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV2Dex = bytes32(0xde2d1a51640f78257713031680d1f306297d957426e912ab21317b9cc9495a41);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      77,  // Pool id: Info -> Rewards contract address -> read -> pid
+      wbtc, // depositToken
+      2, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      4, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx, pnt];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[pnt][weth] = [pnt, weth];
+    storedLiquidationDexes[pnt][weth] = [uniV2Dex];
+    storedLiquidationPaths[weth][wbtc] = [weth, wbtc];
+    storedLiquidationDexes[weth][wbtc] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyPETHMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyPETHMainnet.sol
@@ -1,0 +1,39 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyPETHMainnet is ConvexStrategyUL_V2 {
+
+  address public peth_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x9848482da3Ee3076165ce6497eDA906E66bB85C5); // Info -> LP Token address
+    address rewardPool = address(0xb235205E1096E0Ad221Fb7621a2E2cbaB875bE75); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      122,  // Pool id: Info -> Rewards contract address -> read -> pid
+      weth, // depositToken
+      0, //depositArrayPosition. Find deposit transaction -> input params
+      underlying, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      2, //nTokens -> total number of deposit tokens
+      false, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyPUSDMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyPUSDMainnet.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyPUSDMainnet is ConvexStrategyUL_V2 {
+
+  address public pusd_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0x8EE017541375F6Bcd802ba119bdDC94dad6911A1); // Info -> LP Token address
+    address rewardPool = address(0x83a3CE160915675F5bC7cC3CfDA5f4CeBC7B7a5a); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address dai = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    address curveDeposit = address(0xA79828DF1850E8a3A3064576f380D90aECDD3359); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      91,  // Pool id: Info -> Rewards contract address -> read -> pid
+      dai, // depositToken
+      1, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      4, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][dai] = [weth, dai];
+    storedLiquidationDexes[weth][dai] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyTBTC2Mainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyTBTC2Mainnet.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyTBTC2Mainnet is ConvexStrategyUL_V2 {
+
+  address public tbtc2_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xfa65aa60a9D45623c57D383fb4cf8Fb8b854cC4D); // Info -> LP Token address
+    address rewardPool = address(0x455AC43CcE0E17774C0bF240ba709DD5822102f3); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address wbtc = address(0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599);
+    address curveDeposit = address(0x7AbDBAf29929e7F8621B757D2a7c04d78d633834); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      111,  // Pool id: Info -> Rewards contract address -> read -> pid
+      wbtc, // depositToken
+      2, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      4, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][wbtc] = [weth, wbtc];
+    storedLiquidationDexes[weth][wbtc] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/ConvexStrategyUSDDMainnet.sol
+++ b/contracts/strategies/convex/ConvexStrategyUSDDMainnet.sol
@@ -1,0 +1,44 @@
+pragma solidity 0.5.16;
+
+import "./base/ConvexStrategyUL_V2.sol";
+
+contract ConvexStrategyUSDDMainnet is ConvexStrategyUL_V2 {
+
+  address public usdd_unused; // just a differentiator for the bytecode
+
+  constructor() public {}
+
+  function initializeStrategy(
+    address _storage,
+    address _vault
+  ) public initializer {
+    address underlying = address(0xe6b5CC1B4b47305c58392CE3D359B10282FC36Ea); // Info -> LP Token address
+    address rewardPool = address(0x7D475cc8A5E0416f0e63042547aDB94ca7045A5b); // Info -> Rewards contract address
+    address crv = address(0xD533a949740bb3306d119CC777fa900bA034cd52);
+    address cvx = address(0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B);
+    address dai = address(0x6B175474E89094C44Da98b954EedeAC495271d0F);
+    address curveDeposit = address(0xA79828DF1850E8a3A3064576f380D90aECDD3359); // only needed if deposits are not via underlying
+    bytes32 sushiDex = bytes32(0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a);
+    bytes32 uniV3Dex = bytes32(0x8f78a54cb77f4634a5bf3dd452ed6a2e33432c73821be59208661199511cd94f);
+    ConvexStrategyUL_V2.initializeBaseStrategy(
+      _storage,
+      underlying,
+      _vault,
+      rewardPool, // rewardPool
+      96,  // Pool id: Info -> Rewards contract address -> read -> pid
+      dai, // depositToken
+      1, //depositArrayPosition. Find deposit transaction -> input params
+      curveDeposit, // deposit contract: usually underlying. Find deposit transaction -> interacted contract
+      4, //nTokens -> total number of deposit tokens
+      true, //metaPool -> if LP token address == pool address (at curve)
+      500 // hodlRatio 5%
+    );
+    rewardTokens = [crv, cvx];
+    storedLiquidationPaths[crv][weth] = [crv, weth];
+    storedLiquidationDexes[crv][weth] = [sushiDex];
+    storedLiquidationPaths[cvx][weth] = [cvx, weth];
+    storedLiquidationDexes[cvx][weth] = [sushiDex];
+    storedLiquidationPaths[weth][dai] = [weth, dai];
+    storedLiquidationDexes[weth][dai] = [uniV3Dex];
+  }
+}

--- a/contracts/strategies/convex/base/ConvexStrategyUL_V2.sol
+++ b/contracts/strategies/convex/base/ConvexStrategyUL_V2.sol
@@ -1,0 +1,466 @@
+pragma solidity 0.5.16;
+
+import "@openzeppelin/contracts/math/Math.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
+import "@openzeppelin/contracts/token/ERC20/SafeERC20.sol";
+import "../../../base/interface/IStrategy.sol";
+import "../../../base/upgradability/BaseUpgradeableStrategyUL.sol";
+import "../interface/IBooster.sol";
+import "../interface/IBaseRewardPool.sol";
+import "../../../base/interface/curve/ICurveDeposit_2token.sol";
+import "../../../base/interface/curve/ICurveDeposit_3token.sol";
+import "../../../base/interface/curve/ICurveDeposit_3token_meta.sol";
+import "../../../base/interface/curve/ICurveDeposit_4token.sol";
+import "../../../base/interface/curve/ICurveDeposit_4token_meta.sol";
+import "../../../base/interface/weth/Weth9.sol";
+
+contract ConvexStrategyUL_V2 is IStrategy, BaseUpgradeableStrategyUL {
+
+  using SafeMath for uint256;
+  using SafeERC20 for IERC20;
+
+  address public constant booster = address(0xF403C135812408BFbE8713b5A23a04b3D48AAE31);
+  address public constant weth = address(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+  address public constant multiSigAddr = address(0xF49440C1F012d041802b25A73e5B0B9166a75c02);
+
+  // additional storage slots (on top of BaseUpgradeableStrategy ones) are defined here
+  bytes32 internal constant _POOLID_SLOT = 0x3fd729bfa2e28b7806b03a6e014729f59477b530f995be4d51defc9dad94810b;
+  bytes32 internal constant _DEPOSIT_TOKEN_SLOT = 0x219270253dbc530471c88a9e7c321b36afda219583431e7b6c386d2d46e70c86;
+  bytes32 internal constant _DEPOSIT_ARRAY_POSITION_SLOT = 0xb7c50ef998211fff3420379d0bf5b8dfb0cee909d1b7d9e517f311c104675b09;
+  bytes32 internal constant _CURVE_DEPOSIT_SLOT = 0xb306bb7adebd5a22f5e4cdf1efa00bc5f62d4f5554ef9d62c1b16327cd3ab5f9;
+  bytes32 internal constant _HODL_RATIO_SLOT = 0xb487e573671f10704ed229d25cf38dda6d287a35872859d096c0395110a0adb1;
+  bytes32 internal constant _HODL_VAULT_SLOT = 0xc26d330f887c749cb38ae7c37873ff08ac4bba7aec9113c82d48a0cf6cc145f2;
+  bytes32 internal constant _NTOKENS_SLOT = 0xbb60b35bae256d3c1378ff05e8d7bee588cd800739c720a107471dfa218f74c1;
+  bytes32 internal constant _METAPOOL_SLOT = 0x567ad8b67c826974a167f1a361acbef5639a3e7e02e99edbc648a84b0923d5b7;
+
+  uint256 public constant hodlRatioBase = 10000;
+  address[] public rewardTokens;
+
+  constructor() public BaseUpgradeableStrategyUL() {
+    assert(_POOLID_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.poolId")) - 1));
+    assert(_DEPOSIT_TOKEN_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.depositToken")) - 1));
+    assert(_DEPOSIT_ARRAY_POSITION_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.depositArrayPosition")) - 1));
+    assert(_CURVE_DEPOSIT_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.curveDeposit")) - 1));
+    assert(_HODL_RATIO_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.hodlRatio")) - 1));
+    assert(_HODL_VAULT_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.hodlVault")) - 1));
+    assert(_NTOKENS_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.nTokens")) - 1));
+    assert(_METAPOOL_SLOT == bytes32(uint256(keccak256("eip1967.strategyStorage.metaPool")) - 1));
+  }
+
+  function initializeBaseStrategy(
+    address _storage,
+    address _underlying,
+    address _vault,
+    address _rewardPool,
+    uint256 _poolID,
+    address _depositToken,
+    uint256 _depositArrayPosition,
+    address _curveDeposit,
+    uint256 _nTokens,
+    bool _metaPool,
+    uint256 _hodlRatio
+  ) public initializer {
+
+    // calculate profit sharing fee depending on hodlRatio
+    uint256 profitSharingNumerator = 150;
+    if (_hodlRatio >= 1500) {
+      profitSharingNumerator = 0;
+    } else if (_hodlRatio > 0){
+      // (profitSharingNumerator - hodlRatio/10) * hodlRatioBase / (hodlRatioBase - hodlRatio)
+      // e.g. with default values: (300 - 1000 / 10) * 10000 / (10000 - 1000)
+      // = (300 - 100) * 10000 / 9000 = 222
+      profitSharingNumerator = profitSharingNumerator.sub(_hodlRatio.div(10)) // subtract hodl ratio from profit sharing numerator
+                                    .mul(hodlRatioBase) // multiply with hodlRatioBase
+                                    .div(hodlRatioBase.sub(_hodlRatio)); // divide by hodlRatioBase minus hodlRatio
+    }
+
+    BaseUpgradeableStrategyUL.initialize(
+      _storage,
+      _underlying,
+      _vault,
+      _rewardPool,
+      weth,
+      profitSharingNumerator,  // profit sharing numerator
+      1000, // profit sharing denominator
+      true, // sell
+      0, // sell floor
+      12 hours, // implementation change delay
+      address(0x7882172921E99d590E097cD600554339fBDBc480) //UL Registry
+    );
+
+    address _lpt;
+    (_lpt,,,,,) = IBooster(booster).poolInfo(_poolID);
+    require(_lpt == underlying(), "Pool Info does not match underlying");
+    require(_depositArrayPosition < _nTokens, "Deposit array position out of bounds");
+    require(1 < _nTokens && _nTokens < 5, "_nTokens should be 2, 3 or 4");
+    _setDepositArrayPosition(_depositArrayPosition);
+    _setPoolId(_poolID);
+    _setDepositToken(_depositToken);
+    _setCurveDeposit(_curveDeposit);
+    _setNTokens(_nTokens);
+    _setMetaPool(_metaPool);
+    setUint256(_HODL_RATIO_SLOT, _hodlRatio);
+    setAddress(_HODL_VAULT_SLOT, multiSigAddr);
+    rewardTokens = new address[](0);
+  }
+
+  function setHodlRatio(uint256 _value) public onlyGovernance {
+    uint256 profitSharingNumerator = 300;
+    if (_value >= 3000) {
+      profitSharingNumerator = 0;
+    } else if (_value > 0){
+      // (profitSharingNumerator - hodlRatio/10) * hodlRatioBase / (hodlRatioBase - hodlRatio)
+      // e.g. with default values: (300 - 1000 / 10) * 10000 / (10000 - 1000)
+      // = (300 - 100) * 10000 / 9000 = 222
+      profitSharingNumerator = profitSharingNumerator.sub(_value.div(10)) // subtract hodl ratio from profit sharing numerator
+                                    .mul(hodlRatioBase) // multiply with hodlRatioBase
+                                    .div(hodlRatioBase.sub(_value)); // divide by hodlRatioBase minus hodlRatio
+    }
+    _setProfitSharingNumerator(profitSharingNumerator);
+    setUint256(_HODL_RATIO_SLOT, _value);
+  }
+
+  function hodlRatio() public view returns (uint256) {
+    return getUint256(_HODL_RATIO_SLOT);
+  }
+
+  function setHodlVault(address _address) public onlyGovernance {
+    setAddress(_HODL_VAULT_SLOT, _address);
+  }
+
+  function hodlVault() public view returns (address) {
+    return getAddress(_HODL_VAULT_SLOT);
+  }
+
+  function depositArbCheck() public view returns(bool) {
+    return true;
+  }
+
+  function rewardPoolBalance() internal view returns (uint256 bal) {
+      bal = IBaseRewardPool(rewardPool()).balanceOf(address(this));
+  }
+
+  function exitRewardPool() internal {
+      uint256 stakedBalance = rewardPoolBalance();
+      if (stakedBalance != 0) {
+          IBaseRewardPool(rewardPool()).withdrawAllAndUnwrap(true);
+      }
+  }
+
+  function partialWithdrawalRewardPool(uint256 amount) internal {
+    IBaseRewardPool(rewardPool()).withdrawAndUnwrap(amount, false);  //don't claim rewards at this point
+  }
+
+  function emergencyExitRewardPool() internal {
+    uint256 stakedBalance = rewardPoolBalance();
+    if (stakedBalance != 0) {
+        IBaseRewardPool(rewardPool()).withdrawAllAndUnwrap(false); //don't claim rewards
+    }
+  }
+
+  function unsalvagableTokens(address token) public view returns (bool) {
+    return (token == rewardToken() || token == underlying());
+  }
+
+  function enterRewardPool() internal {
+    address _underlying = underlying();
+    uint256 entireBalance = IERC20(_underlying).balanceOf(address(this));
+    IERC20(_underlying).safeApprove(booster, 0);
+    IERC20(_underlying).safeApprove(booster, entireBalance);
+    IBooster(booster).depositAll(poolId(), true); //deposit and stake
+  }
+
+  /*
+  *   In case there are some issues discovered about the pool or underlying asset
+  *   Governance can exit the pool properly
+  *   The function is only used for emergency to exit the pool
+  */
+  function emergencyExit() public onlyGovernance {
+    emergencyExitRewardPool();
+    _setPausedInvesting(true);
+  }
+
+  /*
+  *   Resumes the ability to invest into the underlying reward pools
+  */
+
+  function continueInvesting() public onlyGovernance {
+    _setPausedInvesting(false);
+  }
+
+  function addRewardToken(address _token, address[] memory _path, bytes32[] memory _dexes) public onlyGovernance {
+    require(_path[_path.length-1] == weth, "Path should end with WETH");
+    require(_path[0] == _token, "Path should start with rewardToken");
+    require(_dexes.length == _path.length-1, "Inconsistent length for path/dexes");
+    rewardTokens.push(_token);
+    storedLiquidationPaths[_token][weth] = _path;
+    storedLiquidationDexes[_token][weth] = _dexes;
+  }
+
+  // We assume that all the tradings can be done on Sushiswap
+  function _liquidateReward() internal {
+    if (!sell()) {
+      // Profits can be disabled for possible simplified and rapoolId exit
+      emit ProfitsNotCollected(sell(), false);
+      return;
+    }
+
+    address _rewardToken = rewardToken();
+    address _universalLiquidator = universalLiquidator();
+    address _depositToken = depositToken();
+
+    for(uint256 i = 0; i < rewardTokens.length; i++){
+      address token = rewardTokens[i];
+      uint256 rewardBalance = IERC20(token).balanceOf(address(this));
+
+      // if the token is the rewardToken then there won't be a path defined because liquidation is not necessary,
+      // but we still have to make sure that the toHodl part is executed.
+      if (rewardBalance == 0 || (storedLiquidationDexes[token][_rewardToken].length < 1) && token != rewardToken()) {
+        continue;
+      }
+
+      uint256 toHodl = rewardBalance.mul(hodlRatio()).div(hodlRatioBase);
+      if (toHodl > 0) {
+        IERC20(token).safeTransfer(hodlVault(), toHodl);
+        rewardBalance = rewardBalance.sub(toHodl);
+        if (rewardBalance == 0) {
+          continue;
+        }
+      }
+
+      if(token == _rewardToken) {
+        // one of the reward tokens is the same as the token that we liquidate to ->
+        // no liquidation necessary
+        continue;
+      }
+
+      IERC20(token).safeApprove(_universalLiquidator, 0);
+      IERC20(token).safeApprove(_universalLiquidator, rewardBalance);
+      // we can accept 1 as the minimum because this will be called only by a trusted worker
+      ILiquidator(_universalLiquidator).swapTokenOnMultipleDEXes(
+        rewardBalance,
+        1,
+        address(this), // target
+        storedLiquidationDexes[token][_rewardToken],
+        storedLiquidationPaths[token][_rewardToken]
+      );
+    }
+
+    uint256 rewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+    notifyProfitInRewardToken(rewardBalance);
+    uint256 remainingRewardBalance = IERC20(_rewardToken).balanceOf(address(this));
+
+    if (remainingRewardBalance == 0) {
+      return;
+    }
+
+    if(_depositToken != _rewardToken) {
+      IERC20(_rewardToken).safeApprove(_universalLiquidator, 0);
+      IERC20(_rewardToken).safeApprove(_universalLiquidator, remainingRewardBalance);
+
+      // we can accept 1 as minimum because this is called only by a trusted role
+      ILiquidator(_universalLiquidator).swapTokenOnMultipleDEXes(
+        remainingRewardBalance,
+        1,
+        address(this), // target
+        storedLiquidationDexes[_rewardToken][_depositToken],
+        storedLiquidationPaths[_rewardToken][_depositToken]
+      );
+    }
+
+    uint256 tokenBalance = IERC20(_depositToken).balanceOf(address(this));
+    if (tokenBalance > 0) {
+      depositCurve();
+    }
+  }
+
+  function depositCurve() internal {
+    address _depositToken = depositToken();
+    address _curveDeposit = curveDeposit();
+
+    uint256 tokenBalance = IERC20(_depositToken).balanceOf(address(this));
+    if (_depositToken != weth) {
+      IERC20(_depositToken).safeApprove(_curveDeposit, 0);
+      IERC20(_depositToken).safeApprove(_curveDeposit, tokenBalance);
+    }
+
+    // we can accept 0 as minimum, this will be called only by trusted roles
+    uint256 minimum = 0;
+    if (nTokens() == 2) {
+      uint256[2] memory depositArray;
+      depositArray[depositArrayPosition()] = tokenBalance;
+      if (_depositToken == weth){
+        WETH9(weth).withdraw(tokenBalance);
+        ICurveDeposit_2token(_curveDeposit).add_liquidity.value(tokenBalance)(depositArray, minimum);
+      } else {
+        ICurveDeposit_2token(_curveDeposit).add_liquidity(depositArray, minimum);
+      }
+    } else if (nTokens() == 3) {
+      uint256[3] memory depositArray;
+      depositArray[depositArrayPosition()] = tokenBalance;
+      if (metaPool()) {
+        ICurveDeposit_3token_meta(_curveDeposit).add_liquidity(underlying(), depositArray, minimum);
+      } else {
+        ICurveDeposit_3token(_curveDeposit).add_liquidity(depositArray, minimum);
+      }
+    } else if (nTokens() == 4) {
+      uint256[4] memory depositArray;
+      depositArray[depositArrayPosition()] = tokenBalance;
+      if (metaPool()) {
+        ICurveDeposit_4token_meta(_curveDeposit).add_liquidity(underlying(), depositArray, minimum);
+      } else {
+        ICurveDeposit_4token(_curveDeposit).add_liquidity(depositArray, minimum);
+      }
+    }
+  }
+
+
+  /*
+  *   Stakes everything the strategy holds into the reward pool
+  */
+  function investAllUnderlying() internal onlyNotPausedInvesting {
+    // this check is needed, because most of the SNX reward pools will revert if
+    // you try to stake(0).
+    if(IERC20(underlying()).balanceOf(address(this)) > 0) {
+      enterRewardPool();
+    }
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawAllToVault() public restricted {
+    address _underlying = underlying();
+    if (address(rewardPool()) != address(0)) {
+      exitRewardPool();
+    }
+    _liquidateReward();
+    IERC20(_underlying).safeTransfer(vault(), IERC20(_underlying).balanceOf(address(this)));
+  }
+
+  /*
+  *   Withdraws all the asset to the vault
+  */
+  function withdrawToVault(uint256 amount) public restricted {
+    address _underlying = underlying();
+    // Typically there wouldn't be any amount here
+    // however, it is possible because of the emergencyExit
+    uint256 entireBalance = IERC20(_underlying).balanceOf(address(this));
+
+    if(amount > entireBalance){
+      // While we have the check above, we still using SafeMath below
+      // for the peace of mind (in case something gets changed in between)
+      uint256 needToWithdraw = amount.sub(entireBalance);
+      uint256 toWithdraw = Math.min(rewardPoolBalance(), needToWithdraw);
+      partialWithdrawalRewardPool(toWithdraw);
+    }
+    IERC20(_underlying).safeTransfer(vault(), amount);
+  }
+
+  /*
+  *   Note that we currently do not have a mechanism here to include the
+  *   amount of reward that is accrued.
+  */
+  function investedUnderlyingBalance() external view returns (uint256) {
+    return rewardPoolBalance()
+      .add(IERC20(underlying()).balanceOf(address(this)));
+  }
+
+  /*
+  *   Governance or Controller can claim coins that are somehow transferred into the contract
+  *   Note that they cannot come in take away coins that are used and defined in the strategy itself
+  */
+  function salvage(address recipient, address token, uint256 amount) external onlyControllerOrGovernance {
+     // To make sure that governance cannot come in and take away the coins
+    require(!unsalvagableTokens(token), "token is defined as not salvagable");
+    IERC20(token).safeTransfer(recipient, amount);
+  }
+
+  /*
+  *   Get the reward, sell it in exchange for underlying, invest what you got.
+  *   It's not much, but it's honest work.
+  *
+  *   Note that although `onlyNotPausedInvesting` is not added here,
+  *   calling `investAllUnderlying()` affectively blocks the usage of `doHardWork`
+  *   when the investing is being paused by governance.
+  */
+  function doHardWork() external onlyNotPausedInvesting restricted {
+    IBaseRewardPool(rewardPool()).getReward();
+    _liquidateReward();
+    investAllUnderlying();
+  }
+
+  /**
+  * Can completely disable claiming UNI rewards and selling. Good for emergency withdraw in the
+  * simplest possible way.
+  */
+  function setSell(bool s) public onlyGovernance {
+    _setSell(s);
+  }
+
+  /**
+  * Sets the minimum amount of CRV needed to trigger a sale.
+  */
+  function setSellFloor(uint256 floor) public onlyGovernance {
+    _setSellFloor(floor);
+  }
+
+  // masterchef rewards pool ID
+  function _setPoolId(uint256 _value) internal {
+    setUint256(_POOLID_SLOT, _value);
+  }
+
+  function poolId() public view returns (uint256) {
+    return getUint256(_POOLID_SLOT);
+  }
+
+  function _setDepositToken(address _address) internal {
+    setAddress(_DEPOSIT_TOKEN_SLOT, _address);
+  }
+
+  function depositToken() public view returns (address) {
+    return getAddress(_DEPOSIT_TOKEN_SLOT);
+  }
+
+  function _setDepositArrayPosition(uint256 _value) internal {
+    setUint256(_DEPOSIT_ARRAY_POSITION_SLOT, _value);
+  }
+
+  function depositArrayPosition() public view returns (uint256) {
+    return getUint256(_DEPOSIT_ARRAY_POSITION_SLOT);
+  }
+
+  function _setCurveDeposit(address _address) internal {
+    setAddress(_CURVE_DEPOSIT_SLOT, _address);
+  }
+
+  function curveDeposit() public view returns (address) {
+    return getAddress(_CURVE_DEPOSIT_SLOT);
+  }
+
+  function _setNTokens(uint256 _value) internal {
+    setUint256(_NTOKENS_SLOT, _value);
+  }
+
+  function nTokens() public view returns (uint256) {
+    return getUint256(_NTOKENS_SLOT);
+  }
+
+  function _setMetaPool(bool _value) internal {
+    setBoolean(_METAPOOL_SLOT, _value);
+  }
+
+  function metaPool() public view returns (bool) {
+    return getBoolean(_METAPOOL_SLOT);
+  }
+
+
+  function finalizeUpgrade() external onlyGovernance {
+    _finalizeUpgrade();
+    setHodlVault(multiSigAddr);
+    setHodlRatio(1000); // 10%
+  }
+
+  function () external payable {} // this is needed for the WETH unwrapping
+}

--- a/scripts/04-deploy-upgradable-strategy.js
+++ b/scripts/04-deploy-upgradable-strategy.js
@@ -1,0 +1,34 @@
+const prompt = require('prompt');
+const hre = require("hardhat");
+const { type2Transaction } = require('./utils.js');
+
+async function main() {
+  console.log("Upgradable strategy deployment.");
+  console.log("Specify a the vault address, and the strategy implementation's name");
+  prompt.start();
+  const addresses = require("../test/test-config.js");
+
+  const {id, vaultAddr, strategyName} = await prompt.get(['vaultAddr', 'strategyName']);
+
+  const StrategyImpl = artifacts.require(strategyName);
+  const impl = await type2Transaction(StrategyImpl.new);
+
+  console.log("Implementation deployed at:", impl.creates);
+
+  const StrategyProxy = artifacts.require('StrategyProxy');
+  const proxy = await type2Transaction(StrategyProxy.new, impl.creates);
+
+  console.log("Proxy deployed at:", proxy.creates);
+
+  const strategy = await StrategyImpl.at(proxy.creates);
+  await type2Transaction(strategy.initializeStrategy, addresses.Storage, vaultAddr);
+
+  console.log("Deployment complete. New strategy deployed and initialised at", proxy.creates);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/test/convex/aleth.js
+++ b/test/convex/aleth.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyAlETHMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex AlETH", function() {
+  // test setup
+  const underlying = "0xC4C319E2D4d66CcA4464C0c2B32c9Bd23ebe784e";
+  const underlyingWhale = "0x0175C38d00a114Bd29FBcaf832e7B1a21033644C";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/apeusd-fraxbp.js
+++ b/test/convex/apeusd-fraxbp.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyApeUSD_FRAXBPMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex ApeUSD-FRAXBP", function() {
+  // test setup
+  const underlying = "0x04b727C7e246CA70d496ecF52E6b6280f3c8077D";
+  const underlyingWhale = "0xecdED8b1c603cF21299835f1DFBE37f10F2a29Af";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/crv-eth-v2.js
+++ b/test/convex/crv-eth-v2.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyCRV_ETHMainnetV2");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex CRV-ETH", function() {
+  // test setup
+  const underlying = "0xEd4064f376cB8d68F770FB1Ff088a3d0F3FF5c4d";
+  const underlyingWhale = "0x28a55C4b4f9615FDE3CDAdDf6cc01FcF2E38A6b0";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/cvx-eth-v2.js
+++ b/test/convex/cvx-eth-v2.js
@@ -1,0 +1,43 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const IFeeForwarder = artifacts.require("IFeeRewardForwarderV6");
+const addresses = require("../test-config.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyCVX_ETHMainnetV2");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex CVX-ETH", function() {
+  // test setup
+  const underlying = "0x3A283D9c08E8b55966afb64C515f5143cf907611";
+  const underlyingWhale = "0xD3B613a48E6fD288571B81bE3e8103A8E4C3e7A5";
+  const liquidationPaths = [
+    {"sushi": [crv, weth, cvx]},
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    const result = await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+
+    const sushidex = "0xcb2d20206d906069351c89a2cb7cdbd96c71998717cd5a82e724d955b654f67a";
+    const bancordex = "0x4bf11b89310db45ea1467e48e832606a6ec7b8735c470fff7cf328e182a7c37e";
+
+    const feeForwarder = await IFeeForwarder.at(await result.controller.feeRewardForwarder());
+    await feeForwarder.configureLiquidation(
+      [cvx, weth, addresses.FARM],
+      [sushidex, bancordex],
+      {from: result.governance}
+    );
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/cvxfxs.js
+++ b/test/convex/cvxfxs.js
@@ -1,0 +1,32 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyCvxFXSMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex cvxFXS", function() {
+  // test setup
+  const underlying = "0xF3A43307DcAFa93275993862Aae628fCB50dC768";
+  const underlyingWhale = "0x94712699C06Ec46b09f31B1aECd078049Dad3Fe3";
+  const fxs = "0x3432B6A60D23Ca0dFCa7761B7ab56459D9C964D0";
+  const liquidationPaths = [
+    {'sushi': [fxs, weth]},
+    {'sushi': [weth, fxs]}
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/dola-fraxbp.js
+++ b/test/convex/dola-fraxbp.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15983140
+const strategyArtifact = artifacts.require("ConvexStrategyDOLA_FRAXBPMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex DOLA-FRAXBP", function() {
+  // test setup
+  const underlying = "0xE57180685E3348589E9521aa53Af0BCD497E884d";
+  const underlyingWhale = "0x5EB3C9a23CC030FD2942089da07aD175B9DAD7dc";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/hbtcv2.js
+++ b/test/convex/hbtcv2.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15983140
+const strategyArtifact = artifacts.require("ConvexStrategyHBTCMainnetV2");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex hBTC", function() {
+  // test setup
+  const underlying = "0xb19059ebb43466C323583928285a49f558E572Fd";
+  const underlyingWhale = "0x7a7A599D2384ed203cFEA49721628aA851E0DA16";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/pbtc.js
+++ b/test/convex/pbtc.js
@@ -1,0 +1,30 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+const pnt = "0x89Ab32156e46F46D02ade3FEcbe5Fc4243B9AAeD";
+
+//This test was developed at blockNumber 15983140
+const strategyArtifact = artifacts.require("ConvexStrategyPBTCMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex pBTC", function() {
+  // test setup
+  const underlying = "0xC9467E453620f16b57a34a770C6bceBECe002587";
+  const underlyingWhale = "0x36b9bB0Fb89f8E74251E45b6d9BbA2926560028A";
+  const liquidationPaths = [{"uni": [pnt, weth]},
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/peth.js
+++ b/test/convex/peth.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15983140
+const strategyArtifact = artifacts.require("ConvexStrategyPETHMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex pETH", function() {
+  // test setup
+  const underlying = "0x9848482da3Ee3076165ce6497eDA906E66bB85C5";
+  const underlyingWhale = "0x5e80E858D446Ce82dE038817bF4AF49ac81473c0";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/pusd.js
+++ b/test/convex/pusd.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyPUSDMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex PUSD", function() {
+  // test setup
+  const underlying = "0x8EE017541375F6Bcd802ba119bdDC94dad6911A1";
+  const underlyingWhale = "0x782803267E9d78212929D22b02cc1032A34760fC";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/tbtc2.js
+++ b/test/convex/tbtc2.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15796660
+const strategyArtifact = artifacts.require("ConvexStrategyTBTC2Mainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex TBTC2", function() {
+  // test setup
+  const underlying = "0xfa65aa60a9D45623c57D383fb4cf8Fb8b854cC4D";
+  const underlyingWhale = "0x2deb3882b844BD83360BbeaF7d901e59664Df204";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});

--- a/test/convex/usdd.js
+++ b/test/convex/usdd.js
@@ -1,0 +1,29 @@
+const { ConvexULTest } = require("./util/convex-ul-test.js");
+
+const crv = "0xD533a949740bb3306d119CC777fa900bA034cd52";
+const cvx = "0x4e3FBD56CD56c3e72c1403e103b45Db9da5B9D2B";
+const weth = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2";
+
+//This test was developed at blockNumber 15983140
+const strategyArtifact = artifacts.require("ConvexStrategyUSDDMainnet");
+
+// Vanilla Mocha test. Increased compatibility with tools that integrate Mocha.
+describe("Mainnet Convex USDD", function() {
+  // test setup
+  const underlying = "0xe6b5CC1B4b47305c58392CE3D359B10282FC36Ea";
+  const underlyingWhale = "0xfe6Bc0f11013642C983e3691A272CB71374F774A";
+  const liquidationPaths = [
+  ];
+
+  let convexULTest = new ConvexULTest();
+
+  before(async () => {
+    await convexULTest.setupTest(underlying, underlyingWhale, liquidationPaths, strategyArtifact);
+  });
+
+  describe("--------- Happy path --------------", () => {
+    it("Farmer should earn money", async () => {
+      await convexULTest.testHappyPath();
+    });
+  });
+});


### PR DESCRIPTION
I've updated the Convex base strategy with some improvements we made in other strategies recently. I've added implementations for a number of pools that are performing well on Convex.

I would like to launch them with a lower performance fee as an experiment. I've set them up with 15% performance fee of which 1/3 (so 5% of total profit) is routed to the msig. With the shrinking incentives we can offer, this lower fee would keep our vaults interesting for users instead of just farming the same opp themselves.

If you guys are onboard I can deploy the vaults and we can see if the lower fee has any impact in attracting funds.